### PR TITLE
ProGuard support

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/UnpackMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/UnpackMojo.java
@@ -1,0 +1,110 @@
+package com.jayway.maven.plugins.android.phase04processclasses;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.IOUtil;
+
+import com.jayway.maven.plugins.android.AbstractAndroidMojo;
+import com.jayway.maven.plugins.android.CommandExecutor;
+
+/**
+ * unpack library.
+ * 
+ * @author hugo.josefson@jayway.com
+ * @goal unpack
+ * @phase process-classes
+ * @requiresDependencyResolution compile
+ */
+public class UnpackMojo extends AbstractAndroidMojo {
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+		CommandExecutor executor = CommandExecutor.Factory
+				.createDefaultCommmandExecutor();
+		executor.setLogger(this.getLog());
+
+		File inputFile = new File(project.getBuild().getDirectory()
+				+ File.separator + project.getBuild().getFinalName() + ".jar");
+
+		if (generateApk) {
+			// Unpack all dependent and main classes
+			unpackClasses(inputFile);
+		}
+	}
+
+	private File unpackClasses(File inputFile) throws MojoExecutionException {
+		File outputDirectory = new File(project.getBuild().getDirectory(),
+				"android-classes");
+		for (Artifact artifact : getRelevantCompileArtifacts()) {
+
+			if (artifact.getFile().isDirectory()) {
+				try {
+					FileUtils
+							.copyDirectory(artifact.getFile(), outputDirectory);
+				} catch (IOException e) {
+					throw new MojoExecutionException(
+							"IOException while copying "
+									+ artifact.getFile().getAbsolutePath()
+									+ " into "
+									+ outputDirectory.getAbsolutePath(), e);
+				}
+			} else {
+				try {
+					unjar(new JarFile(artifact.getFile()), outputDirectory);
+				} catch (IOException e) {
+					throw new MojoExecutionException(
+							"IOException while unjarring "
+									+ artifact.getFile().getAbsolutePath()
+									+ " into "
+									+ outputDirectory.getAbsolutePath(), e);
+				}
+			}
+
+		}
+
+		try {
+			unjar(new JarFile(inputFile), outputDirectory);
+		} catch (IOException e) {
+			throw new MojoExecutionException("IOException while unjarring "
+					+ inputFile.getAbsolutePath() + " into "
+					+ outputDirectory.getAbsolutePath(), e);
+		}
+		return outputDirectory;
+	}
+
+	private void unjar(JarFile jarFile, File outputDirectory)
+			throws IOException {
+		for (Enumeration en = jarFile.entries(); en.hasMoreElements();) {
+			JarEntry entry = (JarEntry) en.nextElement();
+			File entryFile = new File(outputDirectory, entry.getName());
+			if (!entryFile.getParentFile().exists()
+					&& !entry.getName().startsWith("META-INF")) {
+				entryFile.getParentFile().mkdirs();
+			}
+			if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
+				final InputStream in = jarFile.getInputStream(entry);
+				try {
+					final OutputStream out = new FileOutputStream(entryFile);
+					try {
+						IOUtil.copy(in, out);
+					} finally {
+						IOUtils.closeQuietly(out);
+					}
+				} finally {
+					IOUtils.closeQuietly(in);
+				}
+			}
+		}
+	}
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -34,13 +34,16 @@
                     </compile>
                     <process-classes>
                         org.apache.maven.plugins:maven-jar-plugin:jar,
-                        com.jayway.maven.plugins.android.generation2:maven-android-plugin:dex
+                        com.jayway.maven.plugins.android.generation2:maven-android-plugin:unpack
                     </process-classes>
                     <process-test-resources>
                         org.apache.maven.plugins:maven-resources-plugin:testResources
                     </process-test-resources>
                     <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
                     <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                    <prepare-package>
+                        com.jayway.maven.plugins.android.generation2:maven-android-plugin:dex
+                    </prepare-package>
                     <package>
                         com.jayway.maven.plugins.android.generation2:maven-android-plugin:apk
                     </package>


### PR DESCRIPTION
Hi:

  I'm trying to use proguard-maven-plugin with maven-android-plugin, but it seems impossible to let ProGuard process the unpacked class, because it is unpacked and converted to dex immediately. So I split the DexMojo into UnpackMojo and DexMojo, and move DexMojo to prepare-package phase. Now it can work with proguard-maven-plugin.

I would be glad if the patch can be merged, and thank you for the great plugin.

PS: here is the configure of proguard-maven-plugin I'm using, hope it can help you test the patch

```
<build>
    ...
    <plugins>
        ...
        <plugin>
            <groupId>com.pyx4me</groupId>
            <artifactId>proguard-maven-plugin</artifactId>
            <executions>
                <execution>
                    <phase>process-classes</phase>
                    <goals>
                        <goal>proguard</goal>
                    </goals>
                </execution>
            </executions>
            <configuration>
                <injar>android-classes</injar>
                <libs>
                    <lib>${java.home}/lib/rt.jar</lib>
                </libs>
                <obfuscate>false</obfuscate>
                <options>
                    <option>-keep public class * extends android.app.Activity</option>
                    <option>-dontskipnonpubliclibraryclasses</option>
                    <option>-dontoptimize</option>
                    <option>-printmapping map.txt</option>
                    <option>-printseeds seed.txt</option>
                    <option>-ignorewarnings</option>
                </options>
            </configuration>
        </plugin>
        ...
    </plugins>
    ...
</build>
```
