### PR TITLE
Do not get confused by trailing slashes

### DIFF
--- a/src/test/java/com/jayway/maven/plugins/android/AbstractAndroidMojoTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/AbstractAndroidMojoTest.java
@@ -51,7 +51,7 @@ public class AbstractAndroidMojoTest {
         Reflection.field("sdkPlatform").ofType(String.class).in(androidMojo).set("1.6");
         AndroidSdk sdk = androidMojo.getAndroidSdk();
         File path = Reflection.field("sdkPath").ofType(File.class).in(sdk).get();
-        Assert.assertEquals(testSupport.getEnv_ANDROID_HOME(), path.getAbsolutePath());
+        Assert.assertEquals(new File(testSupport.getEnv_ANDROID_HOME()).getAbsolutePath(), path.getAbsolutePath());
     }
 
     @Test

--- a/src/test/java/com/jayway/maven/plugins/android/AndroidSdkTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/AndroidSdkTest.java
@@ -43,13 +43,13 @@ public class AndroidSdkTest {
     @Test
     public void givenToolAdbThenPathIsCommon() {
         final String pathForTool =sdkTestSupport.getSdk_with_platform_1_5().getPathForTool("adb");
-        Assert.assertEquals(sdkTestSupport.getEnv_ANDROID_HOME() + "/tools/adb", pathForTool);
+        Assert.assertEquals(new File(sdkTestSupport.getEnv_ANDROID_HOME() + "/tools/adb").getAbsolutePath(), pathForTool);
     }
 
     @Test
     public void givenToolAndroidThenPathIsCommon() {
         final String pathForTool =sdkTestSupport.getSdk_with_platform_1_5().getPathForTool("android");
-        Assert.assertEquals(sdkTestSupport.getEnv_ANDROID_HOME() + "/tools/android", pathForTool);
+        Assert.assertEquals(new File(sdkTestSupport.getEnv_ANDROID_HOME() + "/tools/android").getAbsolutePath(), pathForTool);
     }
 
     @Test


### PR DESCRIPTION
Hello Hugo,

some of the tests were breaking, when the environment variables contained trailing slashes.

Regards
Mirko
