### PR TITLE
Skip zipalign on non apk

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractZipalignMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractZipalignMojo.java
@@ -87,7 +87,8 @@ public abstract class AbstractZipalignMojo extends AbstractAndroidMojo {
      */
     protected void zipalign() throws MojoExecutionException {
 
-        // If we're not on a supported packaging with just skip
+        // If we're not on a supported packaging with just skip (Issue 87)
+        // http://code.google.com/p/maven-android-plugin/issues/detail?id=87
         if (! SUPPORTED_PACKAGING_TYPES.contains(project.getPackaging())) {
             getLog().info("Skipping zipalign on " + project.getPackaging());
             return;
@@ -116,7 +117,8 @@ public abstract class AbstractZipalignMojo extends AbstractAndroidMojo {
                 getLog().info("with parameters: " + parameters);
                 executor.executeCommand(command, parameters);
 
-                // Attach the resulting artifact
+                // Attach the resulting artifact (Issue 88)
+                // http://code.google.com/p/maven-android-plugin/issues/detail?id=88
                 File aligned = new File(parsedOutputApk);
                 if (aligned.exists()) {
                     projectHelper.attachArtifact(project, "apk", "aligned", aligned);


### PR DESCRIPTION
This branch contains the fix of the issues:
- [87](http://code.google.com/p/maven-android-plugin/issues/detail?id=87): zipalign should be skipped on non APK projects
- [88](http://code.google.com/p/maven-android-plugin/issues/detail?id=88): zipalign should attach the created artifact to the project

The changes are quite simple. For the first one, I just skip if the packaging is not supported.
For the second one, I just use the maven project helper to attach the created artifact.

Regards,

Clement
