### PR TITLE
Fix Issue 137 : 'jvmArguments results in "error: no command specified"'

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -85,18 +85,13 @@ public class DexMojo extends AbstractAndroidMojo {
                         File inputFile) throws MojoExecutionException {
         File classesOutputDirectory = new File(project.getBuild().getDirectory(), "android-classes");
         List<String> commands = new ArrayList<String>();
-        commands.add("-jar");
-        commands.add(getAndroidSdk().getPathForTool("dx.jar"));
         if (jvmArguments != null) {
             for (String jvmArgument : jvmArguments) {
-                if (jvmArgument != null) {
-                    if (jvmArgument.startsWith("-")) {
-                        jvmArgument = jvmArgument.substring(1);
-                    }
-                    commands.add("-J" + jvmArgument);
-                }
+                commands.add(jvmArgument);
             }
         }
+        commands.add("-jar");
+        commands.add(getAndroidSdk().getPathForTool("dx.jar"));
         commands.add("--dex");
         commands.add("--output=" + outputFile.getAbsolutePath());
         commands.add(classesOutputDirectory.getAbsolutePath());


### PR DESCRIPTION
Hi, just a small fix for an issue that came up with 2.9.0-beta-2:

http://code.google.com/p/maven-android-plugin/issues/detail?id=137

Note that '-X' args need to come before the '-jar' args, and should no
longer be prefixed with a '-J' as they were when invoking dex through it's
wrapper.

cheers,
Roberto
