### PR TITLE
sourceDirectories to add resources to apk

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -145,8 +145,20 @@ public class ApkMojo extends AbstractAndroidMojo {
 	/**
 	 * <p>Additional source directories that contain resources to be packaged into the apk.</p>
 	 * <p>These are not source directories, that contain java classes to be compiled. It corresponds to the -df option of the apkbuilder program. It allows you to specify directories, that contain additional resources to be packaged into the apk. </p>
+	 * So an example inside the plugin \<configuration\> could be:
+	 * <pre>
+	 * <configuration>
+	 * 	<androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
+         * 	<assetsDirectory>${project.basedir}/assets</assetsDirectory>
+         * 	<resourceDirectory>${project.basedir}/res</resourceDirectory>
+         * 	<nativeLibrariesDirectory>${project.basedir}/src/main/native</nativeLibrariesDirectory>
+	 *	<sourceDirectories>
+         *   		<sourceDirectory>${project.basedir}/additionals</sourceDirectory>
+	 *	</sourceDirectories>		  
+         * </configuration>
+	 * </pre>
 	 *
-	 * @parameter 
+     	 * @parameter expression="${android.sourcDirectories}" default-value="null"
 	 */
 	private File[] sourceDirectories;
 


### PR DESCRIPTION
small change that adds the possibility to give the plugin
additional "sourcedirectories". Not Source in the meaning of java
classes to be compiled, but sources to be added during the apk goal.
This corresponds to the -rf command line option of the apkbuilder program.
Here is how you use it:

<configuration>
...
 <sourceDirectories>
  <sourceDirectory>/your/dir/with/some/resources/to/add</sourceDirectory>
 </sourceDirectories>
</configuration>
