### PR TITLE
Support for dx '--no-locals' flag

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -57,6 +57,13 @@ public class DexMojo extends AbstractAndroidMojo {
      * @parameter default-value="false"
      */
     private boolean coreLibrary;
+    
+    /**
+     * Decides whether to pass the --no-locals flag to dx.
+     *
+     * @parameter default-value="false"
+     */
+    private boolean noLocals;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -97,6 +104,9 @@ public class DexMojo extends AbstractAndroidMojo {
         }
         commands.add("--dex");
         commands.add("--output=" + outputFile.getAbsolutePath());
+        if (noLocals) {
+        	commands.add("--no-locals");
+        }
         commands.add(classesOutputDirectory.getAbsolutePath());
         if (coreLibrary) {
             commands.add("--core-library");


### PR DESCRIPTION
I would really appreciate if you could add this patch in the next release. This commit add support for passing the optional flag '--no-locals' to dx. I have tested and built with this flag in maven-android-plugin for over 2 months now, and it works fine! Thanks in advance!
