### PR TITLE
Centralize project detection

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/AndroidExtension.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/AndroidExtension.java
@@ -1,7 +1,5 @@
 package com.jayway.maven.plugins.android.common;
 
-import org.apache.maven.project.MavenProject;
-
 public final class AndroidExtension {
 	/** Android application. */
 	public static final String APK = "apk";
@@ -18,14 +16,15 @@ public final class AndroidExtension {
 	
 	
 	/**
-	 * Determine whether or not a {@link MavenProject} is an Android project.
+	 * Determine whether or not a {@link MavenProject}'s packaging is an
+	 * Android project.
 	 * 
-	 * @param project Project instance.
+	 * @param packaging Project packaging.
 	 * @return True if an Android project.
 	 */
-	public static boolean isAndroidProject(MavenProject project) {
-		return APK.equals(project.getPackaging())
-			|| APKLIB.equals(project.getPackaging())
-			|| APKSOURCES.equals(project.getPackaging());
+	public static boolean isAndroidPackaging(String packaging) {
+		return APK.equals(packaging)
+			|| APKLIB.equals(packaging)
+			|| APKSOURCES.equals(packaging);
 	}
 }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/VersionUpdateMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/VersionUpdateMojo.java
@@ -104,7 +104,7 @@ public class VersionUpdateMojo extends AbstractAndroidMojo {
     private boolean             versionCodeAutoIncrement = false;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (!AndroidExtension.isAndroidProject(project)) {
+        if (!AndroidExtension.isAndroidPackaging(project.getPackaging())) {
             return; // skip, not an android project.
         }
 


### PR DESCRIPTION
Centralize detection of whether or not a project is an Android project. More specifically, this allows automatic version incrementing for all types of Android projects.
