### PR TITLE
Fixed issue 148: wrong error message when SDK property is not set. See ht

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -762,10 +762,10 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
                 // There is no <sdk><path> tag in the pom.
 
                 if (sdkPath != null) {
-                    // -Dandroid.sdk.path is set on command line, or via <properties><sdk.path>...
+                    // -Dandroid.sdk.path is set on command line, or via <properties><android.sdk.path>...
                     chosenSdkPath = sdkPath;
                 } else {
-                    // No -Dandroid.sdk.path is set on command line, or via <properties><sdk.path>...
+                    // No -Dandroid.sdk.path is set on command line, or via <properties><android.sdk.path>...
                     chosenSdkPath = new File(getAndroidHomeOrThrow());
                 }
             }
@@ -780,10 +780,10 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
             // There is no <sdk> tag in the pom.
 
             if (sdkPath != null) {
-                // -Dandroid.sdk.path is set on command line, or via <properties><sdk.path>...
+                // -Dandroid.sdk.path is set on command line, or via <properties><android.sdk.path>...
                 chosenSdkPath = sdkPath;
             } else {
-                // No -Dandroid.sdk.path is set on command line, or via <properties><sdk.path>...
+                // No -Dandroid.sdk.path is set on command line, or via <properties><android.sdk.path>...
                 chosenSdkPath = new File(getAndroidHomeOrThrow());
             }
 
@@ -797,7 +797,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
     private String getAndroidHomeOrThrow() throws MojoExecutionException {
         final String androidHome = System.getenv(ENV_ANDROID_HOME);
         if (isBlank(androidHome)) {
-            throw new MojoExecutionException("No Android SDK path could be found. You may configure it in the pom using <sdk><path>...</path></sdk> or <properties><sdk.path>...</sdk.path></properties> or on command-line using -Dandroid.sdk.path=... or by setting environment variable " + ENV_ANDROID_HOME);
+            throw new MojoExecutionException("No Android SDK path could be found. You may configure it in the pom using <sdk><path>...</path></sdk> or <properties><android.sdk.path>...</android.sdk.path></properties> or on command-line using -Dandroid.sdk.path=... or by setting environment variable " + ENV_ANDROID_HOME);
         }
         return androidHome;
     }


### PR DESCRIPTION
Fixed issue 148: wrong error message when SDK property is not set. See http://code.google.com/p/maven-android-plugin/issues/detail?id=148

I just replaced <sdk.path> with <android.sdk.path> in the message of the exception thrown.
