### PR TITLE
Mass (un) deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.android.tools</groupId>
+            <artifactId>ddmlib</artifactId>
+            <version>r10</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>2.2.1</version>

--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -16,6 +16,9 @@
  */
 package com.jayway.maven.plugins.android;
 
+import com.android.ddmlib.AndroidDebugBridge;
+import com.android.ddmlib.IDevice;
+import com.android.ddmlib.InstallException;
 import com.jayway.maven.plugins.android.common.AndroidExtension;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.JXPathNotFoundException;
@@ -428,7 +431,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
         return results;
     }
 
-   /**
+    /**
      * @return a {@code Set} of direct project dependencies. Never {@code null}. This excludes artifacts of the {@code
      *         EXCLUDED_DEPENDENCY_SCOPES} scopes.
      */
@@ -501,26 +504,64 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
      * @throws MojoExecutionException If there is a problem deploying the apk file.
      */
     protected void deployApk(File apkFile) throws MojoExecutionException {
-        CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
-        executor.setLogger(this.getLog());
-        List<String> commands = new ArrayList<String>();
+        AndroidDebugBridge.init(false);
+        AndroidDebugBridge androidDebugBridge = AndroidDebugBridge.createBridge();
+        waitLoop(androidDebugBridge);
 
-        addDeviceParameter(commands);
-
-        commands.add("install");
-        commands.add("-r");
-        commands.add(apkFile.getAbsolutePath());
-        getLog().info(getAndroidSdk().getPathForTool("adb") + " " + commands.toString());
-        try {
-            executor.executeCommand(getAndroidSdk().getPathForTool("adb"), commands, false);
-            final String standardOut = executor.getStandardOut();
-            if (standardOut != null && standardOut.contains("Failure")) {
-                throw new MojoExecutionException("Error deploying " + apkFile + " to device. You might want to add command line parameter -Dandroid.undeployBeforeDeploy=true or add plugin configuration tag <undeployBeforeDeploy>true</undeployBeforeDeploy>\n" + standardOut);
+        if (androidDebugBridge.isConnected()) {
+            List<IDevice> devices = Arrays.asList(androidDebugBridge.getDevices());
+            int numberOfDevices = devices.size();
+            getLog().info("Found " + numberOfDevices + " devices connected with the Android Debug Bridge");
+            if (devices.size() > 0) {
+                getLog().info("Continuing with install of " + apkFile.getAbsolutePath());
+                if (StringUtils.isNotBlank(device)) {
+                    getLog().info("android.device parameter set to " + device);
+                    for (IDevice idevice : devices) {
+                        // deploy to specified device or all emulators or all devices
+                        if (("emulator".equals(device) && idevice.isEmulator())
+                                || ("usb".equals(device) && !idevice.isEmulator())
+                                || (idevice.getAvdName() != null && idevice.getAvdName().equals(device))) {
+                            try {
+                                idevice.installPackage(apkFile.getAbsolutePath(), undeployBeforeDeploy);
+                                getLog().info("Successfully installed to " + idevice.getSerialNumber()  + " (avdName="
+                                        + idevice.getAvdName() + ")");
+                            } catch (InstallException e) {
+                                throw new MojoExecutionException("Install failed.", e);
+                            }
+                        }
+                    }
+                } else {
+                    getLog().info("android.device parameter not set, deploying to all attached devices");
+                    for (IDevice idevice : devices) {
+                        try {
+                            idevice.installPackage(apkFile.getAbsolutePath(), undeployBeforeDeploy);
+                            getLog().info("Successfully installed to " + idevice.getSerialNumber() + " (avdName="
+                                        + idevice.getAvdName() + ")");
+                        } catch (InstallException e) {
+                            throw new MojoExecutionException("Install failed.", e);
+                        }
+                    }
+                }
+            } else {
+                throw new MojoExecutionException("No online devices attached.");
             }
-        } catch (ExecutionException e) {
-            getLog().error(executor.getStandardOut());
-            getLog().error(executor.getStandardError());
-            throw new MojoExecutionException("Error deploying " + apkFile + " to device.", e);
+        } else {
+            throw new MojoExecutionException("Android Debug Bridge is not connected.");
+        }
+    }
+
+    private void waitLoop(AndroidDebugBridge adb) {
+        int trials = 10;
+        while (trials > 0) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            if (adb.isConnected()) {
+                break;
+            }
+            trials--;
         }
     }
 
@@ -580,7 +621,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
         return undeployApk(packageName, true);
     }
 
-    /**
+ /**
      * Undeploys an apk, specified by package name, from a connected emulator or usb device.
      *
      * @param packageName the package name to undeploy.
@@ -589,25 +630,56 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
      *                    directories on the device, <code>false</code> to keep them.
      * @return <code>true</code> if successfully undeployed, <code>false</code> otherwise.
      */
-    protected boolean undeployApk(String packageName, boolean deleteDataAndCacheDirectoriesOnDevice) throws MojoExecutionException {
-        CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
-        executor.setLogger(this.getLog());
-        List<String> commands = new ArrayList<String>();
-        addDeviceParameter(commands);
-        commands.add("uninstall");
-        if (!deleteDataAndCacheDirectoriesOnDevice) {
-            commands.add("-k");  // ('-k' means keep the data and cache directories)
-        }
-        commands.add(packageName);
-        getLog().info(getAndroidSdk().getAdbPath() + " " + commands.toString());
-        try {
-            executor.executeCommand(getAndroidSdk().getAdbPath(), commands, false);
-            getLog().debug(executor.getStandardOut());
-            getLog().debug(executor.getStandardError());
-            return true;
-        } catch (ExecutionException e) {
-            getLog().error(executor.getStandardOut());
-            getLog().error(executor.getStandardError());
+    protected boolean undeployApk(String packageName, boolean deleteDataAndCacheDirectoriesOnDevice)
+            throws MojoExecutionException {
+        AndroidDebugBridge.init(false);
+        AndroidDebugBridge androidDebugBridge = AndroidDebugBridge.createBridge();
+        waitLoop(androidDebugBridge);
+
+        if (androidDebugBridge.isConnected()) {
+            List<IDevice> devices = Arrays.asList(androidDebugBridge.getDevices());
+            int numberOfDevices = devices.size();
+            getLog().info("Found " + numberOfDevices + " devices connected with the Android Debug Bridge");
+            if (devices.size() > 0) {
+                getLog().info("Continuing with uninstall of " + packageName);
+                if (StringUtils.isNotBlank(device)) {
+                    getLog().info("android.device parameter set to " + device);
+                    for (IDevice idevice : devices) {
+                        if (("emulator".equals(device) && idevice.isEmulator())
+                                || ("usb".equals(device) && !idevice.isEmulator())
+                                || (idevice.getAvdName() != null && idevice.getAvdName().equals(device))) {
+
+                            try {
+                                // TODO ... take deleDataAndCacheDirectoriesOnDevice into account somehow
+                                // (not sure though) might be implied
+                                idevice.uninstallPackage(packageName);
+                                getLog().info("Successfully uninstalled from " + idevice.getSerialNumber() + " (avdName="
+                                        + idevice.getAvdName() + ")");
+                            } catch (InstallException e) {
+                                throw new MojoExecutionException("Uninstall failed.", e);
+                            }
+                        }
+                    }
+                } else {
+                    getLog().info("android.device parameter not set, removing on all attached devices");
+                    for (IDevice idevice : devices) {
+                        try {
+                            // TODO ... take deleteDataAndCacheDirectoriesOnDevice into account somehow
+                            idevice.uninstallPackage(packageName);
+                            getLog().info("Successfully uninstalled from " + idevice.getSerialNumber() + " (avdName="
+                                        + idevice.getAvdName() + ")");
+                        } catch (InstallException e) {
+                            throw new MojoExecutionException("Uninstall failed.", e);
+                        }
+                    }
+                }
+                return true;
+            } else {
+                getLog().error("No online devices attached.");
+                return false;
+            }
+        } else {
+            getLog().error("Android Debug Bridge is not connected.");
             return false;
         }
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UndeployMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UndeployMojo.java
@@ -61,6 +61,7 @@ public class UndeployMojo extends AbstractAndroidMojo {
             } else {
                 if (! SUPPORTED_PACKAGING_TYPES.contains(project.getPackaging())) {
                     getLog().info("Skipping undeploy on " + project.getPackaging());
+                    getLog().info("Execute undeploy within an Maven Android project or specify package with e.g. -Dandroid.package=com.simpligility.android.helloflashlight");
                     return;
                 }
                 packageToUndeploy = extractPackageNameFromAndroidManifest(androidManifestFile);


### PR DESCRIPTION
added sdklib depedency, changed so that deploy and undeploy uses the library instead of the adb command, this improves speed at least, enabled so that deploy and undeploy works against all attached devices in one invocation, improved error message

Now you can attach e.g. two devices and have 3 emulators running and go

mvn android:deploy

and it will deploy to all devices. Same for undeploy. Also works outside a project with

mvn android:undeploy -Dandroid.package=x.y.z

If you need help with upstream merges I can do that too btw.. 
