### PR TITLE
Moved the "--core-library" to before the "--output" option to enable the 

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -105,14 +105,15 @@ public class DexMojo extends AbstractAndroidMojo {
         commands.add("-jar");
         commands.add(getAndroidSdk().getPathForTool("dx.jar"));
         commands.add("--dex");
+        if (coreLibrary) {
+            commands.add("--core-library");
+        }
         commands.add("--output=" + outputFile.getAbsolutePath());
         if (noLocals) {
         	commands.add("--no-locals");
         }
         commands.add(classesOutputDirectory.getAbsolutePath());
-        if (coreLibrary) {
-            commands.add("--core-library");
-        }
+
         final String javaExecutable = getJavaExecutable().getAbsolutePath();
         getLog().info(javaExecutable + " " + commands.toString());
         try {


### PR DESCRIPTION
Moved the "--core-library" to before the "--output" option to enable the builds to succeed where the coreLibrary config option is used in the plugin

See issue No. 157
