### PR TITLE
Added property for emulatorCommands (for coverage etc.)

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -232,6 +232,13 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
     protected String customPackage;
 
     /**
+     * Direct commands to the running Emulator (adb -e "command")
+     *
+     * @parameter
+     */
+    protected List emulatorCommands;
+
+    /**
      * @component
      * @readonly
      * @required

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/AbstractInstrumentationMojo.java
@@ -67,6 +67,11 @@ public abstract class AbstractInstrumentationMojo extends AbstractIntegrationtes
         commands.add("shell");
         commands.add("am");
         commands.add("instrument");
+
+        for ( Object emulatorCommand : emulatorCommands ) {
+            commands.add("-e "+emulatorCommand);
+        }
+
         commands.add("-w");
         
         // only run Tests in specific package


### PR DESCRIPTION
Every command is Executed with "adb -e command" during tests

``` xml
<emulatorCommands>
    <command>command1</command>
    <command>command2</command>
 </emulatorCommands>
```

Im using this for Test Coverage
