### PR TITLE
Fix deploy when adb daemon isn't already running

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -518,13 +518,13 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
      * the init call in the library is also synchronized .. just in case.
      * @return
      */
-    private AndroidDebugBridge initAndroidDebugBridge() {
+    private AndroidDebugBridge initAndroidDebugBridge() throws MojoExecutionException {
         synchronized (adbLock) {
             if (!adbInitialized) {
                 AndroidDebugBridge.init(false);
                 adbInitialized = true;
             }
-            AndroidDebugBridge androidDebugBridge = AndroidDebugBridge.createBridge();
+            AndroidDebugBridge androidDebugBridge = AndroidDebugBridge.createBridge(getAndroidSdk().getAdbPath(), false);
             waitUntilConnected(androidDebugBridge);
             return androidDebugBridge;
         }


### PR DESCRIPTION
Hello there - this patch just populates the `AndroidDebugBridge` with the location of adb so it can start the adb daemon if necessary.

If `AndroidDebugBridge` is created _without_ the location of adb then it's **not** able to start the adb daemon - so goals like android:deploy will fail if the adb daemon isn't already running (example log output below).

still enjoying the 3.0.0 alphas :)
Roberto

http://android.git.kernel.org/?p=platform/sdk.git;a=blob;f=ddms/libs/ddmlib/src/com/android/ddmlib/AndroidDebugBridge.java;h=f697cbaad60c017a09bcea7f1550bb72442af340;hb=HEAD#l891

$ mvn android:deploy
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Agit - Git client for Android 1.13-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-android-plugin:3.0.0-alpha-2:deploy (default-cli) @ agit ---
01:15:59 E/DeviceMonitor: Connection attempts: 1
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.128s
[INFO] Finished at: Fri Jul 08 13:16:00 CEST 2011
[INFO] Final Memory: 8M/149M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.jayway.maven.plugins.android.generation2:maven-android-plugin:3.0.0-alpha-2:deploy (default-cli) on project agit: Android Debug Bridge is not connected. -> [Help 1]
