### PR TITLE
Declare real source/target levels for sources, which is 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,8 +237,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -246,8 +246,8 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Build-Source-Version>1.5</Build-Source-Version>
-                            <Build-Target-Version>1.5</Build-Target-Version>
+                            <Build-Source-Version>1.6</Build-Source-Version>
+                            <Build-Target-Version>1.6</Build-Target-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Since 86dd620bededed88b02bf741f969f0702b13b8fb, two methods in
AbstractEmulatorMojo, writeEmulatorStartScriptUnix() and
writeEmulatorStartScriptWindows(), use
java.io.File.setExecutable(boolean) that had been introduced in 1.6.

But compiler and jar plugins still declare 1.5-compatibility. Fix this
by changing to 1.6.

Signed-off-by: Mykola Nikishov mn@mn.com.ua

As I can see, this affects branches origin/master and origin/maven-android-plugin-2.x
