### PR TITLE
Suppress empty error log line.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -666,7 +666,10 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
         } catch (ExecutionException e) {
             throw new MojoExecutionException("Error while trying to figure out package name from inside apk file " + apkFile);
         } finally {
-            getLog().error(executor.getStandardError());
+            String errout = executor.getStandardError();
+            if ((errout != null) && (errout.trim().length() > 0)) {
+                getLog().error(errout);
+            }
         }
     }
 


### PR DESCRIPTION
This is particularly noticeable when building a maven project with Jenkins.
A red [ERROR] line appears in the internal-pre-integration-test build step.
