### PR TITLE
Support to create destination directory in Pull Mojo

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PullMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PullMojo.java
@@ -54,23 +54,23 @@ public class PullMojo extends AbstractAndroidMojo {
      * directory the original file name will be used. Otherwise the new
      * filename will override the source one.
      *
+     * If the destination directory is missing it will be created.
+     * There is some ambiguity if the destination is missing as to
+     * whether it is a file or directory. The directory will be
+     * extracted using FilenameUtils.getFullPath() from the
+     * Commons IO library (see @see "http://commons.apache.org/io/apidocs/
+     * org/apache/commons/io/FilenameUtils.html#getFullPath
+     * (java.lang.String)"
+     * For example:
+     *  <code>/a/b/c</code> will test and create <code>/a/b/</code>
+     *  <code>/a/b/c.txt</code> will test and create <code>/a/b/</code>
+     *  <code>/a/b/c/</code> will test and create <code>/a/b/c/</code>
+     *
      * @parameter expression="${android.pull.destination}"
      * @required
      */
     private File destination;
 
-	/**
-	 * Create destination directory if it doesn't exist (using
-	 * File.mkdirs()). Because we don't know whether the specified
-	 * destination is a directory or file (unless it exists in
-	 * which case this flag is ignored) we assume that unless
-	 * the destination explicity ends with / it will be treated
-	 * as a file (and removed to get the destination directory)
-	 *
-	 * @parameter default-value=false expression="${android.pull.createDestDir}"
-	 */
-	private Boolean createDestDir;
-	
     public void execute() throws MojoExecutionException, MojoFailureException {
         final String sourcePath = source;
         final String destinationPath;
@@ -81,7 +81,7 @@ public class PullMojo extends AbstractAndroidMojo {
         } else {
             destinationPath = destination.getAbsolutePath();
         }
-	    if (createDestDir && !destination.exists()) {
+	    if (!destination.exists()) {
 		    String destPath = destination.getAbsolutePath();
 		    destPath = FilenameUtils.getFullPath(destPath);
 		    File destFile = new File(destPath);


### PR DESCRIPTION
ddmlib does create the destination directory in SyncService.pullFile().
This patch allows you to set the boolean parameter createDestDir to create the destination directory does not exist.
