### PR TITLE
Added "help" goal to fix issue 191

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,14 @@
             </plugin>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generated-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Hi,

this change to the pom adds a "help" goal, as reported in issue http://code.google.com/p/maven-android-plugin/issues/detail?id=191

I checked that the plugin is working on my small private project, but don't have enough experience with maven plugin implemetations yet to add proper it tests for this case.

Regards,
Hakan
