### PR TITLE
Always reinstall APK

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -538,7 +538,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
         doWithDevices(new DeviceCallback(){
             public void doWithDevice(final IDevice device) throws MojoExecutionException {
                 try {
-                    device.installPackage(apkFile.getAbsolutePath(), undeployBeforeDeploy);
+                    device.installPackage(apkFile.getAbsolutePath(), true);
                     getLog().info("Successfully installed "
                         + apkFile.getAbsolutePath() + " to "
                         + device.getSerialNumber()  + " (avdName="


### PR DESCRIPTION
Always reinstall APK, no-op in case undeployBeforeDeploy is set to true (it should install the application as usual if it's not there yet).
