### PR TITLE
Failure of a test run should cause build failure

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/AbstractInstrumentationMojo.java
@@ -219,6 +219,9 @@ public abstract class AbstractInstrumentationMojo extends AbstractIntegrationtes
                     if (testRunListener.hasFailuresOrErrors()) {
                         throw new MojoFailureException("Tests failed on device.");
                     }
+                    if (testRunListener.testRunFailed()) {
+                        throw new MojoFailureException("Test run failed to complete: "+testRunListener.getTestRunFailureCause());
+                    }
                     if (testRunListener.threwException()) {
                         throw new MojoFailureException(testRunListener.getExceptionMessages());
                     }
@@ -285,6 +288,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractIntegrationtes
         private int testCount = 0;
         private int testFailureCount = 0;
         private int testErrorCount = 0;
+        private String testRunFailureCause = null;
 
         private final MavenProject project;
         /** the emulator or device we are running the tests on **/
@@ -492,6 +496,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractIntegrationtes
         }
 
         public void testRunFailed(String errorMessage) {
+            testRunFailureCause = errorMessage;
             getLog().info(INDENT +"Run failed: " + errorMessage);
         }
 
@@ -597,6 +602,17 @@ public abstract class AbstractInstrumentationMojo extends AbstractIntegrationtes
          */
         public boolean hasFailuresOrErrors() {
             return testErrorCount > 0 || testFailureCount > 0;
+        }
+
+        /**
+         * @return if the test run itself failed - a failure in the test infrastructure, not a test failure.
+         */
+        public boolean testRunFailed() {
+            return testRunFailureCause != null;
+        }
+
+        public String getTestRunFailureCause() {
+            return testRunFailureCause;
         }
 
         /**


### PR DESCRIPTION
The ITestRunListener interface has a testRunFailed() method which is called
if the test run itself failed - a failure in the test infrastructure, not a
test failure. This patch fixes the AbstractInstrumentationMojo so that the
build will be failed if testRunFailed() was called.

(I should have caught this in d2858929, gah)

An example of build messages before and after this update follows - the
test run failure here was caused by mounting my SDCard while the integration
test app was supposed to be running on it.

BEFORE:

[INFO] --- maven-android-plugin:3.0.0-alpha-3:internal-integration-test (default-internal-integration-test) @ agit-integration-tests ---
[INFO] Found 1 devices connected with the Android Debug Bridge
[INFO] android.device parameter not set, using all attached devices
[INFO] Running instrumentation tests in com.madgag.agit.tests on 0123456789ABCDEF (avdName=null)
[INFO]   Run started: com.madgag.agit.tests, 0 tests:
[INFO]   Run failed: Unable to find instrumentation info for: ComponentInfo{com.madgag.agit.tests/android.test.InstrumentationTestRunner}
[INFO]   Run ended: 0 ms
[INFO]   Tests run: 0,  Failures: 0,  Errors: 0
[INFO] Report file written to /home/roberto/development/agit-parent/agit-integration-tests/target/surefire-reports/TEST-0123456789ABCDEF_HTC_HTCDesire.xml
[INFO]
[INFO] --- cargo-maven2-plugin:1.1.1:stop (stop-container) @ agit-integration-tests ---
[INFO] [beddedLocalContainer] Jetty 7.x Embedded is stopping...
2011-08-29 17:27:07.938:INFO::stopped o.e.j.w.WebAppContext{/cargocpc,file:/tmp/jetty-0.0.0.0-18181-cargocpc.war-_cargocpc-any-/webapp/},/home/roberto/development/agit-parent/agit-integration-tests/target/cargo/configurations/jetty7x/cargocpc.war
WAI contextDestroyed - javax.servlet.ServletContextEvent[source=ServletContext@o.e.j.w.WebAppContext{/mini-git-server-war-0.4,file:/tmp/jetty-0.0.0.0-18181-mini-git-server-war-0.4.war-_mini-git-server-war-0.4-any-/webapp/},/home/roberto/.m2/repository/com/madgag/mini-git-server-war/0.4/mini-git-server-war-0.4.war]
[2011-08-29 17:27:07,950] INFO  com.google.gerrit.sshd.SshDaemon : Stopped Gerrit SSHD
2011-08-29 17:27:07.952:INFO::stopped o.e.j.w.WebAppContext{/mini-git-server-war-0.4,file:/tmp/jetty-0.0.0.0-18181-mini-git-server-war-0.4.war-_mini-git-server-war-0.4-any-/webapp/},/home/roberto/.m2/repository/com/madgag/mini-git-server-war/0.4/mini-git-server-war-0.4.war
[INFO] [beddedLocalContainer] Jetty 7.x Embedded is stopped
[INFO]
[INFO] --- maven-install-plugin:2.3.1:install (default-install) @ agit-integration-tests ---
[INFO] Installing /home/roberto/development/agit-parent/agit-integration-tests/target/agit-integration-tests-1.25-SNAPSHOT.apk to /home/roberto/.m2/repository/com/madgag/agit-integration-tests/1.25-SNAPSHOT/agit-integration-tests-1.25-SNAPSHOT.apk
[INFO] Installing /home/roberto/development/agit-parent/agit-integration-tests/pom.xml to /home/roberto/.m2/repository/com/madgag/agit-integration-tests/1.25-SNAPSHOT/agit-integration-tests-1.25-SNAPSHOT.pom
[INFO] Installing /home/roberto/development/agit-parent/agit-integration-tests/target/agit-integration-tests-1.25-SNAPSHOT.jar to /home/roberto/.m2/repository/com/madgag/agit-integration-tests/1.25-SNAPSHOT/agit-integration-tests-1.25-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Agit parent POM project ........................... SUCCESS [0.270s]
[INFO] agit test utils ................................... SUCCESS [1.591s]
[INFO] Agit - git client for Android ..................... SUCCESS [27.079s]
[INFO] Agit integration tests ............................ SUCCESS [1:18.589s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1:48.219s
[INFO] Finished at: Mon Aug 29 17:27:14 BST 2011
[INFO] Final Memory: 35M/322M
[INFO] ------------------------------------------------------------------------

AFTER:

[INFO] Running instrumentation tests in com.madgag.agit.tests on 0123456789ABCDEF (avdName=null)
[INFO]   Run started: com.madgag.agit.tests, 0 tests:
[INFO]   Run failed: Unable to find instrumentation info for: ComponentInfo{com.madgag.agit.tests/android.test.InstrumentationTestRunner}
[INFO]   Run ended: 0 ms
[INFO]   Tests run: 0,  Failures: 0,  Errors: 0
[INFO] Report file written to /home/roberto/development/agit-parent/agit-integration-tests/target/surefire-reports/TEST-0123456789ABCDEF_HTC_HTCDesire.xml
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Agit parent POM project ........................... SUCCESS [0.222s]
[INFO] agit test utils ................................... SUCCESS [1.650s]
[INFO] Agit - git client for Android ..................... SUCCESS [26.669s]
[INFO] Agit integration tests ............................ FAILURE [49.740s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1:18.982s
[INFO] Finished at: Mon Aug 29 19:08:03 BST 2011
[INFO] Final Memory: 39M/173M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.jayway.maven.plugins.android.generation2:maven-android-plugin:3.0.0-SNAPSHOT:internal-integration-test (default-internal-integration-test) on project agit-integration-tests: Test run failed to complete: Unable to find instrumentation info for: ComponentInfo{com.madgag.agit.tests/android.test.InstrumentationTestRunner} -> [Help 1]
