### PR TITLE
Ability to start multiple emulators

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -493,7 +493,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
      * the init call in the library is also synchronized .. just in case.
      * @return
      */
-    private AndroidDebugBridge initAndroidDebugBridge() throws MojoExecutionException {
+    protected AndroidDebugBridge initAndroidDebugBridge() throws MojoExecutionException {
         synchronized (adbLock) {
             if (!adbInitialized) {
                 AndroidDebugBridge.init(false);


### PR DESCRIPTION
I altered the startEmulator command to check for the existence of an emulator based on AVD name so that multiple emulators could be started rather than checking for the existence of a single emulator.
