### PR TITLE
Fix Issue 197 Plugin fails to find active devices.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractEmulatorMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractEmulatorMojo.java
@@ -164,6 +164,7 @@ public abstract class AbstractEmulatorMojo extends AbstractAndroidMojo {
 
         	final AndroidDebugBridge androidDebugBridge = initAndroidDebugBridge();
             if (androidDebugBridge.isConnected()) {
+                waitForInitialDeviceList(androidDebugBridge);
                 List<IDevice> devices = Arrays.asList(androidDebugBridge.getDevices());
                 int numberOfDevices = devices.size();
                 getLog().info("Found " + numberOfDevices + " devices connected with the Android Debug Bridge");


### PR DESCRIPTION
Wait for the initial device list to be loaded from the Android Debug Bridge

With the patch applied the plugin will wait for the initial device list if necessary.

[INFO] Waiting for initial device list from the Android Debug Bridge
[INFO] Found 2 devices connected with the Android Debug Bridge
[INFO] android.device parameter set to emulator-50700

This fixes the issues that I was seeing with a jenkins matrix build using multiple executors on a single slave node.
