### PR TITLE
Cannot add resource from what file?

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkBuilder.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkBuilder.java
@@ -265,9 +265,9 @@ public class ApkBuilder {
         try {
             addResourcesFromJarMethod.invoke(builder, new Object[] { jarFile });
         } catch (InvocationTargetException e) {
-            log.error("Cannot add resources from " + jarFile.getAbsolutePath(), e.getCause());
-            throw new MojoExecutionException("Cannot add resources from " + jarFile.getAbsolutePath(),
-                    e.getCause());
+            final String message = "Cannot add resources from " + jarFile.getAbsolutePath();
+            log.error(message, e.getCause());
+            throw new MojoExecutionException(message, e.getCause());
         } catch (Exception e) {
             log.error("Cannot add source folder", e);
             throw new MojoExecutionException("Cannot add resources from jar", e);


### PR DESCRIPTION
Show absolute path to JAR file that causes 'Cannot add resource from jar' error message in ApkBuilder.
