### PR TITLE
Adapt to changed api.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkBuilder.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkBuilder.java
@@ -99,8 +99,25 @@ public class ApkBuilder {
             addResourcesFromJarMethod = apkBuilderClass.getMethod(
                     "addResourcesFromJar", new Class[] { File.class });
 
-            addNativeLibrariesMethod = apkBuilderClass.getMethod(
-                    "addNativeLibraries", new Class[] { File.class, String.class });
+            //The addNativeLibraries signature changed for api 14
+            Method[] builderMethods = apkBuilderClass.getMethods();
+            for (Method method : builderMethods) {
+                if ("addNativeLibraries".equals(method.getName())) {
+                    Class<?>[] parameterTypes = method.getParameterTypes();
+                    //The old method (pre v14) took a second string parameter.
+                    if (parameterTypes.length == 2) {
+                        if (parameterTypes[0] == File.class && parameterTypes[1]== String.class) {
+                            addNativeLibrariesMethod = method;
+                            break;
+                        }
+                    } else if (parameterTypes.length == 1) {
+                        if (parameterTypes[0] == File.class) {
+                            addNativeLibrariesMethod = method;
+                            break;
+                        }
+                    }
+                }
+            }
 
             addSourceFolderMethod = apkBuilderClass.getMethod(
                     "addSourceFolder", new Class[] { File.class });
@@ -290,7 +307,13 @@ public class ApkBuilder {
      */
     public void addNativeLibraries(File nativeFolder, String abiFilter) throws MojoExecutionException {
         try {
-            addNativeLibrariesMethod.invoke(builder, new Object[] { nativeFolder, abiFilter });
+            //The method changed with version 14 of the ADK.
+            //The pre-14 version took a second abiFilter string parameter.
+            if (addNativeLibrariesMethod.getParameterTypes().length == 2) {
+                addNativeLibrariesMethod.invoke(builder, new Object[] { nativeFolder, abiFilter });
+            } else {
+                addNativeLibrariesMethod.invoke(builder, new Object[] { nativeFolder });
+            }
         } catch (InvocationTargetException e) {
             log.error("Cannot add native libraries", e.getCause());
             throw new MojoExecutionException("Cannot add native libraries",


### PR DESCRIPTION
The signature for an SDK method has changed with version 14 of the ADK.

This just fixes the compilation. I don't use native libraries, so I don't know how omitting the abi level affects the call. There's an addFile(File, String) method available, but I don't know if that's related. Anyone using native libraries should probably investigate further.
I also haven't tried with an ADK < 14.
