### PR TITLE
added the variable genDirectoryAidl so that the folder containing generated sources based on aidl can be parameterized

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -61,7 +61,7 @@ import com.jayway.maven.plugins.android.ExecutionException;
 public class GenerateSourcesMojo extends AbstractAndroidMojo {
 
     /**
-     * Override default generated folder
+     * Override default generated folder containing R.java
      *
      * @parameter expression="${android.genDirectory}" default-value="${project.build.directory}/generated-sources/r"
      *
@@ -69,7 +69,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo {
     protected File genDirectory;
     
     /**
-     * Override default generated folder
+     * Override default generated folder containing aidl classes
      *
      * @parameter expression="${android.genDirectoryAidl}" default-value="${project.build.directory}/generated-sources/aidl"
      *


### PR DESCRIPTION
added the variable genDirectoryAidl so that the folder containing generated sources based on aidl can be parameterized
I did not add tests (but I tested locally the plugin parameter is working) since it did not seem to have any tests for the R folder...
