### PR TITLE
Add missing space in install/uninstall failed exception messages

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -513,7 +513,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
                         + DeviceHelper.getDescriptiveName(device));
                 } catch (InstallException e) {
                     throw new MojoExecutionException("Install of "
-                        + apkFile.getAbsolutePath() + "failed.", e);
+                        + apkFile.getAbsolutePath() + " failed.", e);
                 }
             }
         });
@@ -637,7 +637,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
                 } catch (InstallException e) {
                     result.set(false);
                     throw new MojoExecutionException("Uninstall of " +
-                        packageName + "failed.", e);
+                        packageName + " failed.", e);
                 }
             }
         });


### PR DESCRIPTION
Adds a space before the word _failed_ in the exception messages
