### PR TITLE
Removed redundant copy code - fixes issue 200

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -539,10 +539,6 @@ public class ApkMojo extends AbstractAndroidMojo {
                 copyLocalNativeLibraries( nativeLibrariesDirectory, destinationDirectory );
             }
 
-            if ( hasValidBuildNativeLibrariesDirectory ) {
-                copyLocalNativeLibraries( nativeLibrariesOutputDirectory, destinationDirectory );
-            }
-
             if (!artifacts.isEmpty())
             {
                 for (Artifact resolvedArtifact : artifacts)


### PR DESCRIPTION
The redundant code would try to copy the content of the native lib output directory in target to the same location
