### PR TITLE
Ignore optional transient dependencies when resolving artifacts - fixes issue 237

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
@@ -3,7 +3,6 @@ package com.jayway.maven.plugins.android.common;
 import com.jayway.maven.plugins.android.AbstractAndroidMojo;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -12,9 +11,11 @@ import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.RepositorySystemSession;
 import org.sonatype.aether.collection.CollectRequest;
 import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyFilter;
 import org.sonatype.aether.graph.DependencyNode;
 import org.sonatype.aether.repository.RemoteRepository;
 import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.util.filter.AndDependencyFilter;
 import org.sonatype.aether.util.filter.ScopeDependencyFilter;
 import org.sonatype.aether.util.graph.PreorderNodeListGenerator;
 
@@ -125,7 +126,16 @@ public class NativeHelper {
             collectRequest.setRepositories( projectRepos );
             final DependencyNode node = repoSystem.collectDependencies( repoSession, collectRequest ).getRoot();
 
-            final DependencyRequest dependencyRequest = new DependencyRequest( node, new ScopeDependencyFilter( Arrays.asList( "compile", "runtime" ), Arrays.asList( "test" ) ) );
+            final DependencyRequest dependencyRequest = new DependencyRequest( node, new AndDependencyFilter(
+                    new ScopeDependencyFilter( Arrays.asList( "compile", "runtime" ), Arrays.asList( "test" ) ),
+                    // Also exclude any optional dependencies
+                    new DependencyFilter() {
+                        @Override
+                        public boolean accept( DependencyNode dependencyNode, List<DependencyNode> dependencyNodes ) {
+                            return !dependencyNode.getDependency().isOptional();
+                        }
+                    }
+            ));
 
 
             repoSystem.resolveDependencies( repoSession, dependencyRequest );


### PR DESCRIPTION
Added an additional dependency filter to filter out transient dependencies marked as optional 
