### PR TITLE
issue 241 Proguard build fails when java is instaled in Program Files

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -122,9 +122,9 @@ public class ProguardMojo extends AbstractAndroidMojo {
 
         public String toCommandLine() {
             if (filterExpression != null) {
-                return path + "(" + filterExpression + ")";
+                return "\'" + path + "\'(" + filterExpression + ")";
             }
-            return path;
+            return "\'" + path + "\'";
         }
     }
 
@@ -194,16 +194,16 @@ public class ProguardMojo extends AbstractAndroidMojo {
         collectInputFiles(commands);
 
         commands.add("-outjars");
-        commands.add(project.getBuild().getDirectory() + File.separator + PROGUARD_OBFUSCATED_JAR);
+        commands.add("'" + project.getBuild().getDirectory() + File.separator + PROGUARD_OBFUSCATED_JAR + "'");
 
         commands.add("-dump");
-        commands.add(proguardDir + File.separator + "dump.txt");
+        commands.add("'" + proguardDir + File.separator + "dump.txt'");
         commands.add("-printseeds");
-        commands.add(proguardDir + File.separator + "seeds.txt");
+        commands.add("'" + proguardDir + File.separator + "seeds.txt'");
         commands.add("-printusage");
-        commands.add(proguardDir + File.separator + "usage.txt");
+        commands.add("'" + proguardDir + File.separator + "usage.txt'");
         commands.add("-printmapping");
-        commands.add(proguardDir + File.separator + "mapping.txt");
+        commands.add("'" + proguardDir + File.separator + "mapping.txt'");
 
         final String javaExecutable = getJavaExecutable().getAbsolutePath();
         getLog().info(javaExecutable + " " + commands.toString());


### PR DESCRIPTION
Quote all filenames provided to proguard using the method described in the
Proguard manual at http://proguard.sourceforge.net/manual/usage.html#filename

Tested on Windows 7 (using Jenkins 1.447) and Ubuntu 11.10 (maven 3.0.3)

Note I used a single quote rather than a double quote because the latter did not fix the issue on Windows 7.
