### PR TITLE
Fail a device operation if the android.device could not be found.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -575,23 +575,31 @@ public abstract class AbstractAndroidMojo extends AbstractMojo {
             if (devices.size() > 0) {
                 if (StringUtils.isNotBlank(device)) {
                     getLog().info("android.device parameter set to " + device);
+                    boolean deviceFound = false;
                     for (IDevice idevice : devices) {
                         // use specified device or all emulators or all devices
                         if ("emulator".equals(device) && idevice.isEmulator()) {
                             getLog().info("Emulator " + DeviceHelper.getDescriptiveName(idevice) + " found.");
+                            deviceFound = true;
                             deviceCallback.doWithDevice(idevice);
                         } else if ("usb".equals(device) && !idevice.isEmulator()) {
                             getLog().info("Device " + DeviceHelper.getDescriptiveName(idevice) + " found.");
+                            deviceFound = true;
                             deviceCallback.doWithDevice(idevice);
                         } else if (idevice.isEmulator()
                                 && (device.equalsIgnoreCase(idevice.getAvdName())
                                     || device.equalsIgnoreCase(idevice.getSerialNumber()))) {
                             getLog().info("Emulator " + DeviceHelper.getDescriptiveName(idevice) + " found.");
+                            deviceFound = true;
                             deviceCallback.doWithDevice(idevice);
                         } else if (!idevice.isEmulator() && device.equals(idevice.getSerialNumber())) {
                             getLog().info("Device " + DeviceHelper.getDescriptiveName(idevice) + " found.");
+                            deviceFound = true;
                             deviceCallback.doWithDevice(idevice);
                         }
+                    }
+                    if (!deviceFound) {
+                        throw new MojoExecutionException("No device found for android.device=" + device);
                     }
                 } else {
                     getLog().info("android.device parameter not set, using all attached devices");


### PR DESCRIPTION
I inadvertantly was using an incorrect -Dandroid.device= value on my builds and as a consequence my unit tests were not getting run but there was no notification that this was the case.

This patch forces a failure if a specific device is requested but none is found. 

The only potential problem I can see is if some users rely on the fail silently behaviour if they do not have a device present. I did not add anything to allow device presence errors to be skipped but will do if deemed useful.
