### PR TITLE
Capture screenshots from the Android device during integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
             <version>1.12</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.rtyley</groupId>
+            <artifactId>android-screenshot-paparazzo</artifactId>
+            <version>1.6</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -279,7 +279,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo {
                     "see http://developer.android.com/guide/developing/testing/testing_otheride.html");
         }
 
-        doWithDevices(new DeviceCallback() {
+        DeviceCallback instrumentationTestExecutor = new DeviceCallback() {
             public void doWithDevice(final IDevice device) throws MojoExecutionException, MojoFailureException {
                 RemoteAndroidTestRunner remoteAndroidTestRunner =
                     new RemoteAndroidTestRunner(parsedInstrumentationPackage, parsedInstrumentationRunner, device);
@@ -329,7 +329,11 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo {
                     throw new MojoExecutionException("IO problem", e);
                 }
             }
-        });
+        };
+
+        instrumentationTestExecutor = new ScreenshotServiceWrapper(instrumentationTestExecutor, project, getLog());
+
+        doWithDevices(instrumentationTestExecutor);
     }
 
     private void parseConfiguration() {

--- a/src/main/java/com/jayway/maven/plugins/android/ScreenshotServiceWrapper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/ScreenshotServiceWrapper.java
@@ -1,0 +1,62 @@
+package com.jayway.maven.plugins.android;
+
+import static com.github.rtyley.android.screenshot.paparazzo.processors.util.Dimensions.square;
+import static com.jayway.maven.plugins.android.common.DeviceHelper.getDescriptiveName;
+import static org.apache.commons.io.FileUtils.forceMkdir;
+
+import com.android.ddmlib.IDevice;
+import com.github.rtyley.android.screenshot.paparazzo.OnDemandScreenshotService;
+import com.github.rtyley.android.screenshot.paparazzo.processors.AnimatedGifCreator;
+import com.github.rtyley.android.screenshot.paparazzo.processors.ImageSaver;
+import java.io.File;
+import java.io.IOException;
+
+import com.github.rtyley.android.screenshot.paparazzo.processors.ImageScaler;
+import com.github.rtyley.android.screenshot.paparazzo.processors.util.Dimensions;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+public class ScreenshotServiceWrapper implements DeviceCallback {
+
+    private final DeviceCallback delegate;
+    private final Log log;
+    private final File screenshotParentDir;
+
+    public ScreenshotServiceWrapper(DeviceCallback delegate, MavenProject project, Log log) {
+        this.delegate = delegate;
+        this.log = log;
+        screenshotParentDir = new File(project.getBuild().getDirectory(), "screenshots");
+        create(screenshotParentDir);
+    }
+
+
+    @Override
+    public void doWithDevice(final IDevice device) throws MojoExecutionException, MojoFailureException {
+        String deviceName = getDescriptiveName(device);
+
+        File deviceGifFile = new File(screenshotParentDir, deviceName + ".gif");
+        File deviceScreenshotDir = new File(screenshotParentDir, deviceName);
+        create(deviceScreenshotDir);
+
+        OnDemandScreenshotService screenshotService = new OnDemandScreenshotService(device,
+                new ImageSaver(deviceScreenshotDir),
+                new ImageScaler(new AnimatedGifCreator(deviceGifFile), square(320))
+                );
+
+        screenshotService.start();
+
+        delegate.doWithDevice(device);
+
+        screenshotService.finish();
+    }
+
+    private void create(File dir) {
+        try {
+            forceMkdir(dir);
+        } catch (IOException e) {
+            log.warn("Unable to create screenshot directory: "+screenshotParentDir.getAbsolutePath(), e);
+        }
+    }
+}


### PR DESCRIPTION
ddmlib supports capturing screenshots from your Android device, which is awesome, and this commit adds support for capturing select screenshots while running your integration tests- ie robotium-style tests that drive your app - and additionally creates an animated gif of the resulting sequence, which can be pushed to your chatroom on every build to give a quick visual assessment of the state of the app.

Handling the scheduling of the screenshots is tricky, and to this end I've created a small framework to address issues around taking screenshots with ddmlib:
- ddmlib image capture is **slow**, around 600ms+ per image
- if the device screen is updating, the captured image is likely to show
  a _partially-updated_ framebuffer
- ddmlib is invoked on the development environment side of your setup
  (ie your machine executing the Maven build) - your app code can't
  easily take screenshots itself, but in order to get best screenshot
  results your device screen should not be changing when the screenshot
  is taken

The android-screenshot framework addresses these issues:

https://github.com/rtyley/android-screenshot-lib

Your development environment runs an [OnDemandScreenshotService](https://github.com/rtyley/android-screenshot-lib/blob/master/paparazzo/src/main/java/com/github/rtyley/android/screenshot/paparazzo/OnDemandScreenshotService.java), using ddmlib to listen for log messages tagged `screenshot_request`. Your app integration test code just writes one of these log messages when it wants a screenshot taken, and the service obliges by capturing an image from the device. To get the best results, your tests should then pause for a second so that the screenshot is of a static screen. That simple operation is wrapped up for convenience in the [Screenshots](https://github.com/rtyley/android-screenshot-lib/blob/master/celebrity/src/main/java/com/github/rtyley/android/screenshot/celebrity/Screenshots.java) class packaged into the `android-screenshot-celebrity` artifact - but you don't _have_ to use it, if you want to write the log-and-sleeping statements yourself.

For the android-maven-plugin, the screenshots are written to the 'screenshots' folder under the target folder. They are organised into subfolders based on the friendly device name, so you can get a snapshot of how your app looks across several different devices very easily by just running it on a multi-device build - obviously that works with the emulator too.
