### PR TITLE
Update to bug-fix release of android-screenshot lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <dependency>
             <groupId>com.github.rtyley</groupId>
             <artifactId>android-screenshot-paparazzo</artifactId>
-            <version>1.6</version>
+            <version>1.8</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This follows on from pull request #104 and fixes parsing of the key-value pairs that can be passed with log messages to the screenshot-taking paparazzo service - these are only used for naming the screenshot files at the moment.

Additionally, it fixes a race condition that could see the paparazzo service being shut down at the same time as the last screenshot being taken, thus corrupting the animated gif. Works much better now :-)

https://github.com/rtyley/android-screenshot-lib
