### PR TITLE
Set the android.manifest.versionCode as a maven property

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
@@ -165,8 +165,9 @@ public class ManifestUpdateMojo extends AbstractAndroidMojo {
 	protected Integer manifestVersionCode;
 
 	/**
-	  * Auto increment the <code>android:versionCode</code> attribute with each build. The
-	  * resulting value is exposed via the  project property <code>android.manifest.versionCode</code>.
+	  * Auto increment the <code>android:versionCode</code> attribute with each build. The value is
+	  * exposed via the project property <code>android.manifest.versionCodeAutoIncrement</code> and
+	  * the resulting value as <code>android.manifest.versionCode</code>.
 	  *
 	  * @parameter expression="${android.manifest.versionCodeAutoIncrement}" default-value="false"
 	  */
@@ -176,8 +177,9 @@ public class ManifestUpdateMojo extends AbstractAndroidMojo {
 	 * Update the <code>android:versionCode</code> attribute automatically from the project version
 	 * e.g 3.0.1 will become version code 301. As described in this blog post
 	 * http://www.simpligility.com/2010/11/release-version-management-for-your-android-application/
-	 * but done without using resource filtering. The resulting value is exposed via the project
-	 * property <code>android.manifest.versionCode</code>.
+	 * but done without using resource filtering. The value is exposed via the project property
+	 * property <code>android.manifest.versionCodeUpdateFromVersion</code> and the resulting value
+	 * as <code>android.manifest.versionCode</code>.
 	 *
 	 * @parameter expression="${android.manifest.versionCodeUpdateFromVersion}" default-value="false"
 	 */


### PR DESCRIPTION
I was trying to find a way to use the `<versionCodeAutoIncrement>` option and get the resulting `versionCode` out for use later in the build process.

Specifically, I was trying to use maven-resources-plugin to filter a json file with `name`, `versionName` and `versionCode` for use with [HockeyKit](https://github.com/TheRealKerni/HockeyKit).

It's entirely possible I've missed something but this seemed like the simplest way to accomplish that goal and I thought it might be of use to others.
