### PR TITLE
FIX for Mac to avoid that Morseflash build with -Prelease fails on Mac

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -387,7 +387,7 @@ public class ProguardMojo extends AbstractAndroidMojo {
         // that is shipped with the SDK (since that is not a complete Java distribution)
         String javaHome = System.getProperty("java.home");
         String jdkLibsPath = null;
-        if (javaHome.startsWith("/System/Library/Java")) {
+        if (javaHome.startsWith("/System/Library/Java") || javaHome.startsWith("/Library/Java")) {
             // MacOS X uses different naming conventions for JDK installations
             jdkLibsPath = javaHome + "/../Classes";
             addLibraryJar(jdkLibsPath + "/classes.jar");


### PR DESCRIPTION
When trying to build the Morseflash example with the Android Maven plugin 3.2.0 plugin and Proguard 4.7, with mvn -Prelease clean install. the build failed with messages:

[INFO] java.io.IOException: Can't read [/Library/Java/JavaVirtualMachines/1.6.0_31-b04-415.jdk/Contents/Home/lib/rt.jar](No such file or directory)

The fix adds a check for the default value of  java.home when JAVA_HOME is not set in the environment.

When the error occurred, JAVA_HOME was  not set, let Maven resolve the default (see below), and no modifications to the Morseflash pom. The problem occurs with -Prelease only, no problem without -Prelease.

Setting JAVA_HOME in the environment also solved the IOException problem.

To reproduce: unset JAVA_HOME; mvn -Prelease clean install

For reference:
$ unset JAVA_HOME
$ mvn -version
Apache Maven 3.0.3 (r1075438; 2011-02-28 18:31:09+0100)
Maven home: /usr/share/maven
Java version: 1.6.0_31, vendor: Apple Inc.
Java home: /Library/Java/JavaVirtualMachines/1.6.0_31-b04-415.jdk/
Contents/Home
Default locale: en_US, platform encoding: MacRoman
OS name: "mac os x", version: "10.7.3", arch: "x86_64", family: "mac"

Another way to detect Mac would be to check if the Java System Property "os.name" starts with "Mac".
