### PR TITLE
Issue 282: APK mojo does not consider exclusions when pulling in native ...

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
@@ -136,7 +136,7 @@ public class NativeHelper {
             final DependencyNode node = repoSystem.collectDependencies( repoSession, collectRequest ).getRoot();
 
             Collection<String> exclusionPatterns = new ArrayList<String>();
-            if (!dependency.getExclusions().isEmpty())
+            if (dependency.getExclusions() != null && !dependency.getExclusions().isEmpty())
             {
                 for (Exclusion exclusion : dependency.getExclusions()) {
                     exclusionPatterns.add(exclusion.getGroupId()+ ":" +  exclusion.getArtifactId());


### PR DESCRIPTION
This allows you to exclude artifacts from the search paths for transient (native) dependencies (when packaging the apk)
