### PR TITLE
Issue 241 regression - Proguard fails when there are spaces in the JAVA_HOME path

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -206,7 +206,7 @@ public class ProguardMojo extends AbstractAndroidMojo {
                 sb.append(')');
                 return sb.toString();
             } else
-                return path;
+                return  "\'" + path + "\'";
         }
     }
 


### PR DESCRIPTION
Issue 241 has been partially re-introduced.

Quoting is still correct on outjars, dump, printseeds, printusage and printmapping command line arguments.

See http://code.google.com/p/maven-android-plugin/issues/detail?id=241 for original issue.
See https://github.com/jayway/maven-android-plugin/pull/94 for original pull request.
