### PR TITLE
Support transitive apklibs when invoking aapt.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
@@ -247,7 +247,7 @@ public class ApklibMojo extends AbstractAndroidMojo
                 commands.add( resourceDirectory.getAbsolutePath() );
             }
         }
-        for ( Artifact apkLibraryArtifact : getRelevantDependencyArtifacts() )
+        for ( Artifact apkLibraryArtifact : getAllRelevantDependencyArtifacts() )
         {
             if ( apkLibraryArtifact.getType().equals( APKLIB ) )
             {


### PR DESCRIPTION
In the generate sources mojo the apklib dependency extractin would correctly follow
transitive apklib dependencies but when invoking aapt in the apklib mojo only direct
dependencies were being used.
