### PR TITLE
Fix proguard mojo for projects which use the Android version of Apache H...

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -169,8 +169,7 @@ public class ProguardMojo extends AbstractAndroidMojo
     public static final String PROGUARD_OBFUSCATED_JAR = "proguard-obfuscated.jar";
 
     private static final Collection<String> ANDROID_LIBRARY_EXCLUDED_FILTER = Arrays
-            .asList( "org/xml/**", "org/w3c/**", "org/apache/http/**", "java/**", "javax/**",
-                    "android/net/http/AndroidHttpClient.class" );
+            .asList( "org/xml/**", "org/w3c/**", "java/**", "javax/**" );
 
     private static final Collection<String> MAVEN_DESCRIPTOR = Arrays.asList( "META-INF/maven/**" );
     private static final Collection<String> META_INF_MANIFEST = Arrays.asList( "META-INF/MANIFEST.MF" );


### PR DESCRIPTION
...ttpComponents.

Without this patch, our project runs into lots of errors like "can't find referenced class org.apache.http.client.HttpClient" when building a release build.
