### PR TITLE
Add support for annotations when running instrumentation tests

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -243,6 +243,35 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
      */
     protected List<String> testClasses;
 
+
+    /**
+     * <p>Whether to execute tests which are annotated with the given annotations.</p>
+     * <pre>
+     * &lt;annotations&gt;
+     *     &lt;annotation&gt;your.package.name.YourAnnotation&lt;/annotation&gt;
+     * &lt;/annotations&gt;
+     * </pre>
+     * or as e.g. -Dandroid.test.annotations=annotation1,annotation2
+     *
+     * @optional
+     * @parameter expression="${android.test.annotations}
+     */
+    protected List<String> testAnnotations;
+
+    /**
+     * <p>Whether to execute tests which are <strong>not</strong> annotated with the given annotations.</p>
+     * <pre>
+     * &lt;excludeAnnotations&gt;
+     *     &lt;excludeAnnotation&gt;your.package.name.YourAnnotation&lt;/excludeAnnotation&gt;
+     * &lt;/excludeAnnotations&gt;
+     * </pre>
+     * or as e.g. -Dandroid.test.excludeAnnotations=annotation1,annotation2
+     *
+     * @optional
+     * @parameter expression="${android.test.excludeAnnotations}
+     */
+    protected List<String> testExcludeAnnotations;
+
     private boolean classesExists;
     private boolean packagesExists;
 
@@ -252,6 +281,8 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
     private String parsedInstrumentationRunner;
     private List<String> parsedClasses;
     private List<String> parsedPackages;
+    private List<String> parsedAnnotations;
+    private List<String> parsedExcludeAnnotations;
     private String parsedTestSize;
     private Boolean parsedCoverage;
     private String parsedCoverageFile;
@@ -314,6 +345,23 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
                     remoteAndroidTestRunner
                             .setClassNames( parsedClasses.toArray( new String[ parsedClasses.size() ] ) );
                     getLog().info( "Running tests for specified test classes/methods: " + parsedClasses );
+                }
+
+                if ( parsedAnnotations != null )
+                {
+                    for ( String annotation : parsedAnnotations )
+                    {
+                        remoteAndroidTestRunner.addInstrumentationArg( "annotation", annotation );
+                    }
+                }
+
+                if ( parsedExcludeAnnotations != null )
+                {
+                    for ( String annotation : parsedExcludeAnnotations )
+                    {
+                        remoteAndroidTestRunner.addInstrumentationArg( "notAnnotation", annotation );
+                    }
+
                 }
 
                 remoteAndroidTestRunner.setDebug( parsedDebug );
@@ -412,6 +460,22 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
             {
                 parsedClasses = testClasses;
             }
+            if ( test.getAnnotations() != null && ! test.getAnnotations().isEmpty() )
+            {
+                parsedAnnotations = test.getAnnotations();
+            }
+            else
+            {
+                parsedAnnotations =  testAnnotations;
+            }
+            if ( test.getExcludeAnnotations() != null && ! test.getExcludeAnnotations().isEmpty() )
+            {
+                parsedExcludeAnnotations = test.getExcludeAnnotations();
+            }
+            else
+            {
+                parsedExcludeAnnotations = testExcludeAnnotations;
+            }
             if ( test.getPackages() != null && ! test.getPackages().isEmpty() )
             {
                 parsedPackages = test.getPackages();
@@ -476,6 +540,8 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
             parsedInstrumentationPackage = testInstrumentationPackage;
             parsedInstrumentationRunner = testInstrumentationRunner;
             parsedClasses = testClasses;
+            parsedAnnotations = testAnnotations;
+            parsedExcludeAnnotations = testExcludeAnnotations;
             parsedPackages = testPackages;
             parsedTestSize = testTestSize;
             parsedCoverage = testCoverage;

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Test.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Test.java
@@ -40,7 +40,7 @@ public class Test
      */
     private Boolean logOnly;
     /**
-     * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testSize}
+     * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testTestSize}
      */
     private String testSize;
     /**
@@ -55,6 +55,14 @@ public class Test
      * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testClasses}
      */
     protected List<String> classes;
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testAnnotations}
+     */
+    private List<String> annotations;
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testExcludeAnnotations}
+     */
+    private List<String> excludeAnnotations;
 
     public String getSkip()
     {
@@ -109,5 +117,15 @@ public class Test
     public List<String> getClasses()
     {
         return classes;
+    }
+
+    public List<String> getAnnotations()
+    {
+        return annotations;
+    }
+
+    public List<String> getExcludeAnnotations()
+    {
+        return excludeAnnotations;
     }
 }


### PR DESCRIPTION
You can selectively run tests which are (or are not) annotated with
a set of specific user-defined annotations.

Corresponds to

adb shell am instrument -w -e annotation com.android.foo.MyAnnotation
adb shell am instrument -w -e notAnnotation com.android.foo.MyAnnotation
