### PR TITLE
Fixed parsing error message from test

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -955,6 +955,8 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
                     {
                         messageEnd = trace.indexOf( newline + "at" );
                         // match start of stack trace "\r\nat org.junit....."
+	                    if(messageStart > messageEnd)       //':' wasn't found in message but in stack trace
+		                    messageStart = 0;
                     }
                     return trace.substring( messageStart, messageEnd );
                 }


### PR DESCRIPTION
Currently when there is NullPointerException during test, error message isn't parsed correctly preventing generation of test run report. This PR fixes the problem.
