### PR TITLE
Merge Manifests - Use StdSdkLog instead of NullSdkLog 

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/ManifestMerger.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/ManifestMerger.java
@@ -1,4 +1,3 @@
-
 package com.jayway.maven.plugins.android.phase01generatesources;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -36,14 +35,16 @@ public class ManifestMerger
     /**
      * Before being able to use the ManifestMerger, an initialization is required.
      * 
-     * @param log the Mojo Logger
-     * @param sdkLibs the File pointing on {@code sdklib.jar}
-     * @param mergerLib the File pointing on {@code manifmerger.jar}
-     * @throws MojoExecutionException if the ManifestMerger class cannot be loaded
+     * @param log
+     *            the Mojo Logger
+     * @param sdkLibs
+     *            the File pointing on {@code sdklib.jar}
+     * @param mergerLib
+     *            the File pointing on {@code manifmerger.jar}
+     * @throws MojoExecutionException
+     *             if the ManifestMerger class cannot be loaded
      */
-    @SuppressWarnings( {
-    "unchecked", "rawtypes"
-    } )
+    @SuppressWarnings( { "unchecked", "rawtypes" } )
     public void initialize( Log log, File sdkLibs, File mergerLib ) throws MojoExecutionException
     {
         if ( processMethod != null && merger != null )
@@ -60,9 +61,8 @@ public class ManifestMerger
         Class mergerLogClass = null;
         try
         {
-            mlLoader = new URLClassLoader( new URL[] {
-                mergerLib.toURI().toURL()
-            }, ManifestMerger.class.getClassLoader() );
+            mlLoader = new URLClassLoader( new URL[] { mergerLib.toURI().toURL() },
+                    ManifestMerger.class.getClassLoader() );
             manifestMergerClass = mlLoader.loadClass( "com.android.manifmerger.ManifestMerger" );
             log.debug( "ManifestMerger loaded " + manifestMergerClass );
             mergerLogClass = mlLoader.loadClass( "com.android.manifmerger.MergerLog" );
@@ -80,14 +80,12 @@ public class ManifestMerger
         }
 
         // Loads the NullSdkLog class
-        Class nullSdkLogClass = null;
+        Class stdSdkLogClass = null;
         try
         {
-            URLClassLoader child = new URLClassLoader( new URL[] {
-                sdkLibs.toURI().toURL()
-            }, mlLoader );
-            nullSdkLogClass = child.loadClass( "com.android.sdklib.NullSdkLog" );
-            log.debug( "NullSdkLog loaded " + nullSdkLogClass );
+            URLClassLoader child = new URLClassLoader( new URL[] { sdkLibs.toURI().toURL() }, mlLoader );
+            stdSdkLogClass = child.loadClass( "com.android.sdklib.StdSdkLog" );
+            log.debug( "StdSdkLog loaded " + stdSdkLogClass );
         }
         catch ( MalformedURLException e )
         {
@@ -113,12 +111,10 @@ public class ManifestMerger
 
         try
         {
-            Method getLoggerMethod = nullSdkLogClass.getMethod( "getLogger" );
-            Object sdkLog = getLoggerMethod.invoke( null );
-
-            Method wrapSdkLogMethod = mergerLogClass.getMethod( "wrapSdkLog", nullSdkLogClass.getInterfaces()[0] );
+            Constructor stdSdkLogConstructor = stdSdkLogClass.getDeclaredConstructors()[0];
+            Object sdkLog = stdSdkLogConstructor.newInstance();
+            Method wrapSdkLogMethod = mergerLogClass.getMethod( "wrapSdkLog", stdSdkLogClass.getInterfaces()[0] );
             Object iMergerLog = wrapSdkLogMethod.invoke( null, sdkLog.getClass().getInterfaces()[0].cast( sdkLog ) );
-
             Constructor manifestMergerConstructor = manifestMergerClass.getDeclaredConstructors()[0];
             merger = manifestMergerConstructor.newInstance( iMergerLog );
         }
@@ -145,11 +141,15 @@ public class ManifestMerger
     /**
      * Merge the AndroidManifests
      * 
-     * @param paramFile1 The destination File for the merged content
-     * @param paramFile2 The original AndroidManifest to merge into
-     * @param paramArayOfFile The array of APKLIB manifests to merge
+     * @param paramFile1
+     *            The destination File for the merged content
+     * @param paramFile2
+     *            The original AndroidManifest to merge into
+     * @param paramArayOfFile
+     *            The array of APKLIB manifests to merge
      * @return
-     * @throws MojoExecutionException if there is a problem merging
+     * @throws MojoExecutionException
+     *             if there is a problem merging
      */
     public boolean process( File paramFile1, File paramFile2, File[] paramArayOfFile ) throws MojoExecutionException
     {


### PR DESCRIPTION
Switch to use the StdSdkLog so that merge errors from the SDK will get displayed in the console output.
