### PR TITLE
fixed bug: tests are not run when more packages are specified

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -336,8 +336,11 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
 
                 if ( packagesExists )
                 {
-                    remoteAndroidTestRunner.setTestPackageName( packagesList );
-                    getLog().info( "Running tests for specified test packages: " + packagesList );
+                    for ( String str : packagesList.split( "," ) )
+                    {
+                        remoteAndroidTestRunner.setTestPackageName( str );
+                        getLog().info( "Running tests for specified test package: " + str );
+                    }
                 }
 
                 if ( classesExists )


### PR DESCRIPTION
parameter android.test.packages wasn't handled correctly
