### PR TITLE
Updated Manifest Merge functionality to support SDK Tools R21.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/manifmerger/ManifestMerger.java
+++ b/src/main/java/com/jayway/maven/plugins/android/manifmerger/ManifestMerger.java
@@ -1,0 +1,66 @@
+package com.jayway.maven.plugins.android.manifmerger;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * This class is a front for the ManifestMerger contained in the
+ * {@code manifmerger.jar}. It is dynamically loaded and reflection is used to
+ * delegate the methods
+ * 
+ * @author tombollwitt
+ */
+public class ManifestMerger
+{
+    /**
+     * The Manifest Merger instance
+     */
+    private static MergeStrategy merger;
+
+    /**
+     * Before being able to use the ManifestMerger, an initialization is
+     * required.
+     * 
+     * @param log the Mojo Logger
+     * @param sdkLibs the File pointing on {@code sdklib.jar}
+     * @param mergerLib the File pointing on {@code manifmerger.jar}
+     * @throws MojoExecutionException if the ManifestMerger class cannot be
+     *         loaded
+     */
+    public void initialize( Log log, File sdkPath, int toolsVersion ) throws MojoExecutionException
+    {
+        if ( merger != null )
+        {
+            // Already initialized
+            return;
+        }
+
+        merger = MergerInitializerFactory.getInitializer( log, toolsVersion, sdkPath );
+
+    }
+
+    /**
+     * Creates a new ManifestMerger. The class must be initialized before
+     * calling this constructor.
+     */
+    public ManifestMerger( Log log, File sdkPath, int toolsVersion ) throws MojoExecutionException
+    {
+        initialize( log, sdkPath, toolsVersion );
+    }
+
+    /**
+     * Merge the AndroidManifests
+     * 
+     * @param mergedFile The destination File for the merged content
+     * @param apkManifest The original AndroidManifest to merge into
+     * @param libraryManifests The array of APKLIB manifests to merge
+     * @return
+     * @throws MojoExecutionException if there is a problem merging
+     */
+    public boolean process( File mergedFile, File apkManifest, File[] libraryManifests ) throws MojoExecutionException
+    {
+        return merger.process( mergedFile, apkManifest, libraryManifests );
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergeStrategy.java
+++ b/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergeStrategy.java
@@ -1,0 +1,24 @@
+package com.jayway.maven.plugins.android.manifmerger;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * MergeStrategy interface
+ * @author tombollwitt
+ * 
+ */
+public interface MergeStrategy
+{
+    /**
+     * Merges the APKLIB manifests with the APK manifest
+     * 
+     * @param mergedFile The final merged AndroidManifest file.
+     * @param apkManifest The original AndroidManifest file of the APK.
+     * @param libraryManifests Array of AndroidManifests for the APKLIBs
+     * @return
+     * @throws MojoExecutionException
+     */
+    boolean process( File mergedFile, File apkManifest, File[] libraryManifests ) throws MojoExecutionException;
+}

--- a/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergeStrategyR20.java
+++ b/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergeStrategyR20.java
@@ -1,0 +1,135 @@
+package com.jayway.maven.plugins.android.manifmerger;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * MergeStrategy for SDK Tools R20
+ * @author tombollwitt
+ *
+ */
+public class MergeStrategyR20 implements MergeStrategy
+{
+    /**
+     * The Mojo logger
+     */
+    Log log;
+
+    /**
+     * The method that does the merging.
+     */
+    Method processMethod;
+
+    /**
+     * The ManifestMerger class
+     */
+    Object merger;
+
+    @SuppressWarnings( { "unchecked", "rawtypes" } )
+    public MergeStrategyR20( Log log, File sdkPath ) throws MojoExecutionException
+    {
+
+        File mergerLib = new File( sdkPath + "/tools/lib/manifmerger.jar" );
+        File sdkLibs = new File( sdkPath + "/tools/lib/sdklib.jar" );
+
+        URLClassLoader mlLoader = null;
+        Class manifestMergerClass = null;
+        Class mergerLogClass = null;
+        try
+        {
+            mlLoader = new URLClassLoader( new URL[] { mergerLib.toURI().toURL() },
+                    ManifestMerger.class.getClassLoader() );
+            manifestMergerClass = mlLoader.loadClass( "com.android.manifmerger.ManifestMerger" );
+            log.debug( "ManifestMerger loaded " + manifestMergerClass );
+            mergerLogClass = mlLoader.loadClass( "com.android.manifmerger.MergerLog" );
+            log.debug( "ManifestMerger loaded " + mergerLogClass );
+        }
+        catch ( MalformedURLException e )
+        {
+            // This one cannot happen.
+            throw new RuntimeException( "Cannot create a correct URL from file " + mergerLib.getAbsolutePath() );
+        }
+        catch ( ClassNotFoundException e )
+        {
+            log.error( "Cannot find required class", e );
+            throw new MojoExecutionException( "Cannot find the required class", e );
+        }
+
+        // Loads the StdSdkLog class
+        Class stdSdkLogClass = null;
+        try
+        {
+            URLClassLoader child = new URLClassLoader( new URL[] { sdkLibs.toURI().toURL() }, mlLoader );
+            stdSdkLogClass = child.loadClass( "com.android.sdklib.StdSdkLog" );
+            log.debug( "StdSdkLog loaded " + stdSdkLogClass );
+        }
+        catch ( MalformedURLException e )
+        {
+            // This one cannot happen.
+            throw new RuntimeException( "Cannot create a correct URL from file " + sdkLibs.getAbsolutePath() );
+        }
+        catch ( ClassNotFoundException e )
+        {
+            log.error( "Cannot find required class", e );
+            throw new MojoExecutionException( "Cannot find the required class", e );
+        }
+
+        // In order to improve performance and to check that all methods are
+        // available we cache used methods.
+        try
+        {
+            processMethod = manifestMergerClass.getMethod( "process", File.class, File.class, File[].class );
+        }
+        catch ( Exception e )
+        {
+            log.error( "Cannot find required method", e );
+            throw new MojoExecutionException( "Cannot find the required method", e );
+        }
+
+        try
+        {
+            Constructor stdSdkLogConstructor = stdSdkLogClass.getDeclaredConstructors()[0];
+            Object sdkLog = stdSdkLogConstructor.newInstance();
+            Method wrapSdkLogMethod = mergerLogClass.getMethod( "wrapSdkLog", stdSdkLogClass.getInterfaces()[0] );
+            Object iMergerLog = wrapSdkLogMethod.invoke( null, sdkLog.getClass().getInterfaces()[0].cast( sdkLog ) );
+            Constructor manifestMergerConstructor = manifestMergerClass.getDeclaredConstructors()[0];
+            merger = manifestMergerConstructor.newInstance( iMergerLog );
+        }
+        catch ( InvocationTargetException e )
+        {
+            log.error( "Cannot create the ManifestMerger object", e.getCause() );
+            throw new MojoExecutionException( "Cannot create the ManifestMerger object", e.getCause() );
+        }
+        catch ( Exception e )
+        {
+            log.error( "Cannot create the ManifestMerger object", e );
+            throw new MojoExecutionException( "Cannot create the ManifestMerger object", e );
+        }
+    }
+
+    /**
+     * @see {@link MergeStrategy#process(File, File, File[])}
+     */
+    @Override
+    public boolean process( File mergedFile, File apkManifest, File[] libraryManifests ) throws MojoExecutionException
+    {
+        try
+        {
+            return (Boolean) processMethod.invoke( merger, mergedFile, apkManifest, libraryManifests );
+        }
+        catch ( Exception e )
+        {
+            log.error( "Cannot merge the manifests", e );
+            throw new MojoExecutionException( "Cannot merge the manifests", e );
+        }
+    }
+
+}

--- a/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergeStrategyR21.java
+++ b/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergeStrategyR21.java
@@ -1,7 +1,4 @@
-package com.jayway.maven.plugins.android.phase01generatesources;
-
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
+package com.jayway.maven.plugins.android.manifmerger;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -10,58 +7,47 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 
 /**
- * This class is a front for the ManifestMerger contained in the {@code manifmerger.jar}. It is dynamically loaded and
- * reflection is used to delegate the methods
+ * MergeStrategy for SDK Tools R21
+ * @author tombollwitt
+ *
  */
-public class ManifestMerger
+public class MergeStrategyR21 implements MergeStrategy
 {
     /**
      * The Mojo logger
      */
-    private static Log log;
+    Log log;
 
     /**
-     * The Manifest Merger instance
+     * The method that does the merging.
      */
-    private static Object merger;
+    Method processMethod;
 
     /**
-     * The ManifestMerger.process Method
+     * The ManifestMerger class
      */
-    private static Method processMethod;
+    Object merger;
 
-    /**
-     * Before being able to use the ManifestMerger, an initialization is required.
-     * 
-     * @param log the Mojo Logger
-     * @param sdkLibs the File pointing on {@code sdklib.jar}
-     * @param mergerLib the File pointing on {@code manifmerger.jar}
-     * @throws MojoExecutionException if the ManifestMerger class cannot be loaded
-     */
-    @SuppressWarnings( {
-    "unchecked", "rawtypes"
-    } )
-    public void initialize( Log log, File sdkLibs, File mergerLib ) throws MojoExecutionException
+    @SuppressWarnings( { "unchecked", "rawtypes" } )
+    public MergeStrategyR21( Log log, File sdkPath ) throws MojoExecutionException
     {
-        if ( processMethod != null && merger != null )
-        {
-            // Already initialized
-            return;
-        }
 
-        ManifestMerger.log = log;
+        File mergerLib = new File( sdkPath + "/tools/lib/manifmerger.jar" );
+        File commonLib = new File( sdkPath + "/tools/lib/common.jar" );
 
-        // Load the ManifestMerger and MergerLog classes
         URLClassLoader mlLoader = null;
         Class manifestMergerClass = null;
         Class mergerLogClass = null;
         try
         {
-            mlLoader = new URLClassLoader( new URL[] {
-                mergerLib.toURI().toURL()
-            }, ManifestMerger.class.getClassLoader() );
+            mlLoader = new URLClassLoader( new URL[] { mergerLib.toURI().toURL() },
+                    ManifestMerger.class.getClassLoader() );
             manifestMergerClass = mlLoader.loadClass( "com.android.manifmerger.ManifestMerger" );
             log.debug( "ManifestMerger loaded " + manifestMergerClass );
             mergerLogClass = mlLoader.loadClass( "com.android.manifmerger.MergerLog" );
@@ -78,18 +64,21 @@ public class ManifestMerger
             throw new MojoExecutionException( "Cannot find the required class", e );
         }
 
-        // Loads the NullSdkLog class
+        // Loads the StdLogger class
         Class stdSdkLogClass = null;
+        Class logLevel = null;
         try
         {
-            URLClassLoader child = new URLClassLoader( new URL[] { sdkLibs.toURI().toURL() }, mlLoader );
-            stdSdkLogClass = child.loadClass( "com.android.sdklib.StdSdkLog" );
-            log.debug( "StdSdkLog loaded " + stdSdkLogClass );
+            URLClassLoader child = new URLClassLoader( new URL[] { commonLib.toURI().toURL() }, mlLoader );
+            stdSdkLogClass = child.loadClass( "com.android.utils.StdLogger" );
+            log.debug( "StdLogger loaded " + stdSdkLogClass );
+            logLevel = child.loadClass( "com.android.utils.StdLogger$Level" );
+            log.debug( "Level loaded " + logLevel );
         }
         catch ( MalformedURLException e )
         {
             // This one cannot happen.
-            throw new RuntimeException( "Cannot create a correct URL from file " + sdkLibs.getAbsolutePath() );
+            throw new RuntimeException( "Cannot create a correct URL from file " + commonLib.getAbsolutePath() );
         }
         catch ( ClassNotFoundException e )
         {
@@ -97,10 +86,11 @@ public class ManifestMerger
             throw new MojoExecutionException( "Cannot find the required class", e );
         }
 
-        // In order to improve performance and to check that all methods are available we cache used methods.
+        // In order to improve performance and to check that all methods are
+        // available we cache used methods.
         try
         {
-            processMethod = manifestMergerClass.getMethod( "process", File.class, File.class, File[].class );
+            processMethod = manifestMergerClass.getMethod( "process", File.class, File.class, File[].class, Map.class );
         }
         catch ( Exception e )
         {
@@ -110,12 +100,13 @@ public class ManifestMerger
 
         try
         {
+            Enum e = Enum.valueOf( logLevel, "VERBOSE" );
             Constructor stdSdkLogConstructor = stdSdkLogClass.getDeclaredConstructors()[0];
-            Object sdkLog = stdSdkLogConstructor.newInstance();
+            Object sdkLog = stdSdkLogConstructor.newInstance( e );
             Method wrapSdkLogMethod = mergerLogClass.getMethod( "wrapSdkLog", stdSdkLogClass.getInterfaces()[0] );
             Object iMergerLog = wrapSdkLogMethod.invoke( null, sdkLog.getClass().getInterfaces()[0].cast( sdkLog ) );
             Constructor manifestMergerConstructor = manifestMergerClass.getDeclaredConstructors()[0];
-            merger = manifestMergerConstructor.newInstance( iMergerLog );
+            merger = manifestMergerConstructor.newInstance( iMergerLog, null );
         }
         catch ( InvocationTargetException e )
         {
@@ -130,27 +121,14 @@ public class ManifestMerger
     }
 
     /**
-     * Creates a new ManifestMerger. The class must be initialized before calling this constructor.
+     * @see {@link MergeStrategy#process(File, File, File[])}
      */
-    public ManifestMerger( Log log, File sdkLibs, File mergerLib ) throws MojoExecutionException
-    {
-        initialize( log, sdkLibs, mergerLib );
-    }
-
-    /**
-     * Merge the AndroidManifests
-     * 
-     * @param paramFile1 The destination File for the merged content
-     * @param paramFile2 The original AndroidManifest to merge into
-     * @param paramArayOfFile The array of APKLIB manifests to merge
-     * @return
-     * @throws MojoExecutionException if there is a problem merging
-     */
-    public boolean process( File paramFile1, File paramFile2, File[] paramArayOfFile ) throws MojoExecutionException
+    @Override
+    public boolean process( File mergedFile, File apkManifest, File[] libraryManifests ) throws MojoExecutionException
     {
         try
         {
-            return (Boolean) processMethod.invoke( merger, paramFile1, paramFile2, paramArayOfFile );
+            return (Boolean) processMethod.invoke( merger, mergedFile, apkManifest, libraryManifests, null );
         }
         catch ( Exception e )
         {
@@ -158,4 +136,5 @@ public class ManifestMerger
             throw new MojoExecutionException( "Cannot merge the manifests", e );
         }
     }
+
 }

--- a/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergerInitializerFactory.java
+++ b/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergerInitializerFactory.java
@@ -1,0 +1,47 @@
+package com.jayway.maven.plugins.android.manifmerger;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Factory for building MergeStrategies
+ * @author tombollwitt
+ * 
+ */
+public class MergerInitializerFactory
+{
+
+    /**
+     * Constant for SDK Tools R20
+     */
+    private static final int R20 = 20;
+    /**
+     * Constant for SDK Tools R21
+     */
+    private static final int R21 = 21;
+
+    /**
+     * Returns the MergeStrategy for the specified version of the SDK Tools.
+     * Currently supports Revisions: 20, 21.
+     * 
+     * @param log The Mojo Log
+     * @param toolsVersion The version of the SDK Tools
+     * @param sdkPath The path to the Android SDK
+     * @return
+     * @throws MojoExecutionException
+     */
+    public static MergeStrategy getInitializer( Log log, int toolsVersion, File sdkPath ) throws MojoExecutionException
+    {
+        switch ( toolsVersion )
+        {
+        case R20:
+            return new MergeStrategyR20( log, sdkPath );
+        case R21:
+            return new MergeStrategyR21( log, sdkPath );
+        default:
+            throw new MojoExecutionException( "Unsupported SDK Tools Revision: " + toolsVersion );
+        }
+    }
+}


### PR DESCRIPTION
Added support for SDK Tools R21.
I updated the Manifest merging code to check the Tools version in the ANDROID_HOME/tools/source.properties file. Based on the version a factory will return a manifest strategy class that has all the reflection to get the correct classes and will execute the merge.
I also moved the merge classes to a separate package to help keep them organized.
