### PR TITLE
Return value of installPackage() was being ignored.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -605,7 +605,12 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
             {
                 try
                 {
-                    device.installPackage( apkFile.getAbsolutePath(), true );
+                    String result = device.installPackage( apkFile.getAbsolutePath(), true );
+                    if ( device != null )
+                    {
+                        throw new MojoExecutionException( "Install of " + apkFile.getAbsolutePath()
+                                + " failed - [" + result + "]" );
+                    }
                     getLog().info( "Successfully installed " + apkFile.getAbsolutePath() + " to "
                             + DeviceHelper.getDescriptiveName( device ) );
                 }


### PR DESCRIPTION
From docs  the return value of installPackages() returns and error code, or null if success. This was being ignored.

Errors like INSTALL_FAILED_SHARED_USER_INCOMPATIBLE were being silently ignored.

Before:

[INFO] Found 1 devices connected with the Android Debug Bridge
[INFO] android.device parameter not set, using all attached devices
[INFO] Successfully installed backup.apk to LG-F180K-ce93d35f_LGE_LG-F180K
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

After:

[ERROR] Failed to execute goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.4.1-SNAPSHOT:deploy (default-cli) on project backup: Install of backup.apk failed - [INSTALL_FAILED_SHARED_USER_INCOMPATIBLE] -> [Help 1]
