### PR TITLE
Allow the specification of patterns to exclude jar files from resource inclusion

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -262,6 +262,8 @@ public class ApkMojo extends AbstractAndroidMojo
      * dependencies. Matching jar files will not have their resources added to the
      * resulting APK.
      * 
+     * The patterns are standard Java regexes.
+     * 
      * @parameter
      */
     private String[] excludeJarResources;


### PR DESCRIPTION
Hello!

For various reasons, we do our own resource inclusion for dependency jars in our Android projects. Unfortunately, the plugin currently unconditionally includes the contents of all jar files into the resulting apk, resulting in huge bloat and redundant copies of files.

I've added a parameter to the "apk" goal that allows users to specify a list of Java regular expressions. These patterns are matched against each jar file in turn and if a match is found, the jar file is excluded from dependency inclusion. The changes are small and affect only the ApkMojo (and do nothing if not explicitly enabled).
