### PR TITLE
Fix for issue 303

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
@@ -614,12 +614,12 @@ public class NdkBuildMojo extends AbstractAndroidMojo
                 if ( "a".equals( project.getPackaging() ) )
                 {
                     return name.startsWith(
-                            "lib" + project.getArtifactId() ) && name.endsWith( ".a" );
+                            "lib" + ndkFinalLibraryName ) && name.endsWith( ".a" );
                 }
                 else
                 {
                     return name.startsWith(
-                            "lib" + project.getArtifactId() ) && name.endsWith( ".so" );
+                            "lib" + ndkFinalLibraryName ) && name.endsWith( ".so" );
                 }
             }
         } );


### PR DESCRIPTION
Now accept method returns true if there is library lib[ndkFinalLibraryName]*.so or .a built, not lib[artifactId] as before.
I've tested it on my private project and it seems to be doing the job.
