### PR TITLE
Issue 303 resolution

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
@@ -610,12 +610,13 @@ public class NdkBuildMojo extends AbstractAndroidMojo
         {
             public boolean accept( final File dir, final String name )
             {
-            	String libraryName = ndkFinalLibraryName;
-            	
-            	if ( libraryName == null || libraryName.isEmpty() ) {
-            		libraryName = project.getArtifactId();
-            	}
-            	
+                String libraryName = ndkFinalLibraryName;
+                
+                if ( libraryName == null || libraryName.isEmpty() )
+                {
+                    libraryName = project.getArtifactId();
+                }
+                
                 // FIXME: The following logic won't work for an APKLIB building a static library
                 if ( "a".equals( project.getPackaging() ) )
                 {


### PR DESCRIPTION
If ndkFinalLibraryName is provided, it will be used to look for a native library artifact instead of project.getArtifactId(). If it isn't, or is empty, artifactId will be used.
I've tested it with samples and am happy to report all builds succeeded.

One thing to remark is that I had to use -Dcheckstyle.skip=true to build it, as it reported " 7 Checkstyle violations" - recently I didn't have that. Has the configuration changed recently? Should I fix issues not related to code I modified?
