### PR TITLE
`android:run` fix for relative packages on activities' names

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RunMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RunMojo.java
@@ -239,8 +239,22 @@ public class RunMojo extends AbstractAndroidMojo
                 LauncherInfo launcherInfo;
 
                 launcherInfo = new LauncherInfo();
-                launcherInfo.activity = activities.item( 0 ).getAttributes().getNamedItem( "android:name" )
+                String activityName = activities.item( 0 ).getAttributes().getNamedItem( "android:name" )
                         .getNodeValue();
+
+                if ( ! activityName.contains( "." ) )
+                {
+                    activityName = "." + activityName;
+                }
+
+                if ( activityName.startsWith( "." ) )
+                {
+                    String packageName = document.getElementsByTagName( "manifest" ).item( 0 ).getAttributes()
+                            .getNamedItem( "package" ).getNodeValue();
+                    activityName = packageName + activityName;
+                }
+
+                launcherInfo.activity = activityName;
 
                 launcherInfo.packageName = renameManifestPackage != null
                     ? renameManifestPackage


### PR DESCRIPTION
This patch fixes `android:run` in 2 situations:
1. an app declares its launcher activity's name with implicit package (ie: "MyActivity", like maven-android-plugin-samples' "ApiDemo" activity)
2. an app uses, simultaneously
   - renameManifestPackage and
   - declares its launcher activity's name with relative package, ie ".ui.MyActivity"
