### PR TITLE
Adds support for predexing libraries to speed up dexing for application

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Dex.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Dex.java
@@ -25,6 +25,10 @@ public class Dex
      * Mirror of {@link com.jayway.maven.plugins.android.phase08preparepackage.DexMojo#dexOptimize}
      */
     private Boolean optimize;
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.phase08preparepackage.DexMojo#dexPreDex}
+     */
+    private Boolean preDex;
 
     public String[] getJvmArguments()
     {
@@ -44,5 +48,10 @@ public class Dex
     public Boolean isOptimize()
     {
         return optimize;
+    }
+
+    public Boolean isPreDex()
+    {
+        return preDex;
     }
 }


### PR DESCRIPTION
From sdk release 21, android supports pre-dexing of jar files to speed up application build time.

I have integrated support for that in the maven plugin, I am thinking of adding a flag to enable or disable it or fail gracefully if the sdk version is not r21?

Let me know if it will useful for your guys and any other suggestions.
