### PR TITLE
Read  <ndk><path>...</path></ndk> setting when resolving AndroidNdk

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Ndk.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Ndk.java
@@ -18,17 +18,19 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Configuration for an Android NDK. Only receives config parameter values, and there is no logic in here. Logic is in
+ * Configuration for an Android NDK. Only receives config parameter values, and
+ * there is no logic in here. Logic is in
  * {@link com.jayway.maven.plugins.android.AndroidNdk}.
- *
+ * 
  * @author Johan Lindquist <johanlindquist@gmail.com>
  */
 public class Ndk
 {
 
     /**
-     * Directory of the installed Android NDK, for example <code>/usr/local/android-ndk-r4</code>
-     *
+     * Directory of the installed Android NDK, for example
+     * <code>/usr/local/android-ndk-r4</code>
+     * 
      * @see com.jayway.maven.plugins.android.phase05compile.NdkBuildMojo#ndkPath
      */
     private File path;
@@ -137,5 +139,227 @@ public class Ndk
      *
      */
     private String buildWarningsRegularExpression;
+
+    public File getPath()
+    {
+        return path;
+    }
+
+    public void setPath( File path )
+    {
+        this.path = path;
+    }
+
+    public List<HeaderFilesDirective> getHeaderFilesDirectives()
+    {
+        return headerFilesDirectives;
+    }
+
+    public void setHeaderFilesDirectives(
+            List<HeaderFilesDirective> headerFilesDirectives )
+    {
+        this.headerFilesDirectives = headerFilesDirectives;
+    }
+
+    public Boolean getUseHeaderArchives()
+    {
+        return useHeaderArchives;
+    }
+
+    public void setUseHeaderArchives( Boolean useHeaderArchives )
+    {
+        this.useHeaderArchives = useHeaderArchives;
+    }
+
+    public Boolean getAttachHeaderFiles()
+    {
+        return attachHeaderFiles;
+    }
+
+    public void setAttachHeaderFiles( Boolean attachHeaderFiles )
+    {
+        this.attachHeaderFiles = attachHeaderFiles;
+    }
+
+    public Boolean getUseLocalSrcIncludePaths()
+    {
+        return useLocalSrcIncludePaths;
+    }
+
+    public void setUseLocalSrcIncludePaths( Boolean useLocalSrcIncludePaths )
+    {
+        this.useLocalSrcIncludePaths = useLocalSrcIncludePaths;
+    }
+
+    public String getBuildExecutable()
+    {
+        return buildExecutable;
+    }
+
+    public void setBuildExecutable( String buildExecutable )
+    {
+        this.buildExecutable = buildExecutable;
+    }
+
+    public String getBuildAdditionalCommandline()
+    {
+        return buildAdditionalCommandline;
+    }
+
+    public void setBuildAdditionalCommandline( String buildAdditionalCommandline )
+    {
+        this.buildAdditionalCommandline = buildAdditionalCommandline;
+    }
+
+    public String getToolchain()
+    {
+        return toolchain;
+    }
+
+    public void setToolchain( String toolchain )
+    {
+        this.toolchain = toolchain;
+    }
+
+    public String getClassifier()
+    {
+        return classifier;
+    }
+
+    public void setClassifier( String classifier )
+    {
+        this.classifier = classifier;
+    }
+
+    public Boolean getClearNativeArtifacts()
+    {
+        return clearNativeArtifacts;
+    }
+
+    public void setClearNativeArtifacts( Boolean clearNativeArtifacts )
+    {
+        this.clearNativeArtifacts = clearNativeArtifacts;
+    }
+
+    public Boolean getAttachNativeArtifacts()
+    {
+        return attachNativeArtifacts;
+    }
+
+    public void setAttachNativeArtifacts( Boolean attachNativeArtifacts )
+    {
+        this.attachNativeArtifacts = attachNativeArtifacts;
+    }
+
+    public String getBuildDirectory()
+    {
+        return buildDirectory;
+    }
+
+    public void setBuildDirectory( String buildDirectory )
+    {
+        this.buildDirectory = buildDirectory;
+    }
+
+    public String getFinalLibraryName()
+    {
+        return finalLibraryName;
+    }
+
+    public void setFinalLibraryName( String finalLibraryName )
+    {
+        this.finalLibraryName = finalLibraryName;
+    }
+
+    public String getMakefile()
+    {
+        return makefile;
+    }
+
+    public void setMakefile( String makefile )
+    {
+        this.makefile = makefile;
+    }
+
+    public String getApplicationMakefile()
+    {
+        return applicationMakefile;
+    }
+
+    public void setApplicationMakefile( String applicationMakefile )
+    {
+        this.applicationMakefile = applicationMakefile;
+    }
+
+    public Boolean getMaxJobs()
+    {
+        return maxJobs;
+    }
+
+    public void setMaxJobs( Boolean maxJobs )
+    {
+        this.maxJobs = maxJobs;
+    }
+
+    public String getTarget()
+    {
+        return target;
+    }
+
+    public void setTarget( String target )
+    {
+        this.target = target;
+    }
+
+    public String getArchitecture()
+    {
+        return architecture;
+    }
+
+    public void setArchitecture( String architecture )
+    {
+        this.architecture = architecture;
+    }
+
+    public Boolean getSkipStripping()
+    {
+        return skipStripping;
+    }
+
+    public void setSkipStripping( Boolean skipStripping )
+    {
+        this.skipStripping = skipStripping;
+    }
+
+    public Map<String, String> getSystemProperties()
+    {
+        return systemProperties;
+    }
+
+    public void setSystemProperties( Map<String, String> systemProperties )
+    {
+        this.systemProperties = systemProperties;
+    }
+
+    public Boolean getIgnoreBuildWarnings()
+    {
+        return ignoreBuildWarnings;
+    }
+
+    public void setIgnoreBuildWarnings( Boolean ignoreBuildWarnings )
+    {
+        this.ignoreBuildWarnings = ignoreBuildWarnings;
+    }
+
+    public String getBuildWarningsRegularExpression()
+    {
+        return buildWarningsRegularExpression;
+    }
+
+    public void setBuildWarningsRegularExpression(
+            String buildWarningsRegularExpression )
+    {
+        this.buildWarningsRegularExpression = buildWarningsRegularExpression;
+    }
 
 }

--- a/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
@@ -19,10 +19,8 @@ import com.jayway.maven.plugins.android.ExecutionException;
 import com.jayway.maven.plugins.android.common.AetherHelper;
 import com.jayway.maven.plugins.android.common.AndroidExtension;
 import com.jayway.maven.plugins.android.common.NativeHelper;
-import com.jayway.maven.plugins.android.config.ConfigPojo;
 import com.jayway.maven.plugins.android.config.PullParameter;
 import com.jayway.maven.plugins.android.configuration.HeaderFilesDirective;
-import com.jayway.maven.plugins.android.configuration.Ndk;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
@@ -61,30 +59,6 @@ public class NdkBuildMojo extends AbstractAndroidMojo
      * Name of the subdirectory of 'target' where we put the generated makefile
      */
     public static final String NDK_MAKFILE_DIRECTORY = "ndk-build";
-    
-    /**
-     * <p>The Android NDK to use.</p>
-     * <p>Looks like this:</p>
-     * <pre>
-     * &lt;ndk&gt;
-     *     &lt;path&gt;/opt/android-ndk-r4&lt;/path&gt;
-     * &lt;/ndk&gt;
-     * </pre>
-     * <p>The <code>&lt;path&gt;</code> parameter is optional. The default is the setting of the ANDROID_NDK_HOME
-     * environment variable. The parameter can be used to override this setting with a different environment variable
-     * like this:</p>
-     * <pre>
-     * &lt;ndk&gt;
-     *     &lt;path&gt;${env.ANDROID_NDK_HOME}&lt;/path&gt;
-     * &lt;/ndk&gt;
-     * </pre>
-     * <p>or just with a hardcoded absolute path. The parameters can also be configured from command-line with parameter
-     * <code>-Dandroid.ndk.path</code>.</p>
-     *
-     * @parameter
-     */
-    @ConfigPojo( prefix = "ndk" )
-    private Ndk ndk;
 
     /**
      * Allows for overriding the default ndk-build executable.


### PR DESCRIPTION
- I did some debugging and found out that the  &lt;ndk>&lt;path>&lt;/path>&lt;/ndk> setting was simply ignored during Ndk builds. This is what this fix is for.
- I checked this on native sample projects (BTW, the testAppearance ConfigureMorseActivityTest.testAppearance cries about the INJECT_EVENTS permission and I couldn't build everything from sample projects beacuse of it)
- I was also thinking whether it would be useful to create a field for output of getAndroidNdk, where on first call it would be defined and afterwards the first result would be returned (the proper AndroidNdk object reference). I haven't done it but I may try to add it in two or three days if you think it is a good idea

NOTE: this is a first change on this branch. I'm still a noob on the git field, and I think I should be able to continue work on this branch after this pull request is fullfilled. If not - reject this and I will either send a new branch with these changes or send it in bulk after I finish everything.

Changes commited:
- Added getters and setters to NDK, 
- Moved NDK ndk field from NdkBuildMojo to AbstractAndroidMojo, 
- Added ndk.getPath() (the &lt;ndk>&lt;path>&lt;/path>&lt;/ndk>) to getAndroidNdk implementation, 
- changed so that:
- \- if a command line parameter android.ndkpath is available, it gets picked first, then 
- \- if &lt;ndk>&lt;path>&lt;/path>&lt;/ndk> is available it gets picked, then
- \- if an ANDROID_NDK_HOME env var is available, it gets picked
- I also changed the description of order in javadocs.
