### PR TITLE
ManifestUpdateMojo: null checks for xml version/encoding

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
@@ -484,9 +484,12 @@ public class ManifestUpdateMojo extends AbstractAndroidMojo
         try
         {
             writer = new FileWriter( manifestFile, false );
-            String xmldecl = String
+            if ( doc.getXmlEncoding() != null && doc.getXmlVersion() != null )
+            {
+                String xmldecl = String
                     .format( "<?xml version=\"%s\" encoding=\"%s\"?>%n", doc.getXmlVersion(), doc.getXmlEncoding() );
-            writer.write( xmldecl );
+                writer.write( xmldecl );                
+            }
             Result result = new StreamResult( writer );
 
             xformer.transform( source, result );


### PR DESCRIPTION
Added null checks for writing the xml version/encoding. This is needed when updating a Merged manifest at build time. e.g. - updating the versionName in SNAPSHOT builds with a build timestamp.

The SDK manifest merging process removes the xml version/encoding defined in the original APK manifest from the merged manifest.
