### PR TITLE
Fix NDK gdbserver paths

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AndroidNdk.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AndroidNdk.java
@@ -173,12 +173,15 @@ public class AndroidNdk
         }
     }
 
-
-    public File getGdbServer( String toolchain ) throws MojoExecutionException
+    public File getGdbServer( String ndkArchitecture ) throws MojoExecutionException
     {
         final File gdbServerFile;
-
-        gdbServerFile = new File( ndkPath, "toolchains/" + toolchain + "/prebuilt/gdbserver" );
+        String toolchain = "";
+        if ( "armeabi".equals( ndkArchitecture ) || "armeabi-v7a".equals( ndkArchitecture ) )
+        {
+            ndkArchitecture = "arm";
+        }
+        gdbServerFile = new File( ndkPath, "prebuilt/android-" + ndkArchitecture + "/gdbserver/gdbserver" );
 
         // Some basic validation
         if ( ! gdbServerFile.exists() )

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -958,7 +958,7 @@ public class ApkMojo extends AbstractAndroidMojo
             if ( apkDebug )
             {
                 // Copy the gdbserver binary to libs/<architecture>/
-                final File gdbServerFile = getAndroidNdk().getGdbServer( apkNativeToolchain );
+                final File gdbServerFile = getAndroidNdk().getGdbServer( architecture );
                 final File destDir = new File( destinationDirectory, architecture );
                 final File destFile = new File( destDir, "gdbserver" );
                 if ( ! destFile.exists() )


### PR DESCRIPTION
Adding multi-arch support on debugging(currently broken for all but arm).
Breaking compatibility with ndk < 8b (paths changed).
