### PR TITLE
FIX: Mkdirs for proguardFile.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -460,6 +460,11 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
         }
         if ( proguardFile != null )
         {
+            File parentFolder = proguardFile.getParentFile();
+            if ( parentFolder != null )
+            {
+                parentFolder.mkdirs();
+            }
             commands.add( "-G" );
             commands.add( proguardFile.getAbsolutePath() );
         }


### PR DESCRIPTION
Automatically create directories for the new "proguardFile" option. Otherwise the build may crash with

> [INFO] ERROR: Unable to open class file .\target\proguard\proguard-file.txt: No such file or directory
