### PR TITLE
support for including/excluding packages in Emma coverage data

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Emma.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Emma.java
@@ -26,6 +26,13 @@ public class Emma
      */
     private String outputMetaFile;
 
+    private String filters;
+
+    public String getFilters()
+    {
+        return filters;
+    }
+
     public Boolean isEnable()
     {
         return enable;

--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/EmmaMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/EmmaMojo.java
@@ -77,6 +77,10 @@ public class EmmaMojo extends AbstractAndroidMojo
                     + parsedEmmaClassFolders );
             getLog().debug( "configuration:  parsedOutputMetadataFile " + parsedOutputMetadataFile );
             InstrProcessor processor = InstrProcessor.create();
+            if ( emma.getFilters() != null )
+            {
+                processor.setInclExclFilter( emma.getFilters().split( "," ) );
+            }
             processor.setInstrPath( parsedEmmaClassFolders, true );
             processor.setInstrOutDir( parsedEmmaClassFolders[ 0 ] ); //always to first define folder
             processor.setMetaOutFile( parsedOutputMetadataFile );


### PR DESCRIPTION
Sometimes, users don't want all packages to be included in Emma coverage data, for example generated classes.

With this patch, it's possible to explicitly include or exclude packages and/or classes via Maven configuration.

e.g. 

<emma>
...
<filters>-com.idont.want.this.package.included.*</filters>
</emma>
