### PR TITLE
android:push directories not working on windows

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PushMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PushMojo.java
@@ -195,7 +195,7 @@ public class PushMojo extends AbstractAndroidMojo
                     // make the file's path relative - this is kind of a hack but it
                     // works just fine in this controlled environment
                     String filePath = file.getAbsolutePath().substring( sourceFile.getAbsolutePath().length() );
-
+                    filePath = filePath.replace(System.getProperty("file.separator"),"/");
                     result.put( file.getAbsolutePath(), destinationPath + filePath );
                 }
             }


### PR DESCRIPTION
pushing directories did not work on windows because file separators were not changed to linux format.
