### PR TITLE
enable transitive native dependencies for apklib

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
@@ -170,7 +170,7 @@ public class ApklibMojo extends AbstractAndroidMojo
                 {
                     if ( apkLibraryArtifact.getType().equals( APKLIB ) )
                     {
-                        final File apklibLibsDirectory = new File( getLibraryUnpackDirectory( apkLibraryArtifact )
+                        final File apklibLibsDirectory = new File( getLibraryUnpackDirectory( apkLibraryArtifact ) + "/"
                                 + NATIVE_LIBRARIES_FOLDER + "/" + ndkArchitecture );
 
                         if ( apklibLibsDirectory.exists() )


### PR DESCRIPTION
Fixes a problem where an apklib will drop native libraries from other apklibs that it depends on.
