### PR TITLE
using obfuscated transitive dependencies for apklib dependencies

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -166,8 +166,7 @@ public class DexMojo extends AbstractAndroidMojo
 
     private Set< File > filterProguardObfuscatedJars( Set< File > inputFiles )
     {
-
-        // in order to not include files twice - obfuscated and not obfuscated
+        // in order to not include files twice - obfuscated and not obfuscated ones
         Map< String, List< File > > files = new HashMap< String, List< File > >( );
         for ( File eachFile : inputFiles )
         {
@@ -186,14 +185,14 @@ public class DexMojo extends AbstractAndroidMojo
         
         File obfuscatedJarsFolder = new File( project.getBuild().getDirectory(), "classes" );
 
-        getLog().debug( "Check obfuscated jars in " + obfuscatedJarsFolder.getAbsolutePath() );
+        getLog().debug( "Searching for obfuscated jars in " + obfuscatedJarsFolder.getAbsolutePath() );
 
         String[] jarFiles = findFilesInDirectory( obfuscatedJarsFolder, "*.jar" );
         for ( String eachJarFilename : jarFiles )
         {
             File eachJarFile = new File( obfuscatedJarsFolder, eachJarFilename );
 
-            getLog().debug( "Exclude obfuscated jar  " + eachJarFile.getAbsolutePath() );
+            getLog().debug( "Exclude original jar for obfuscated jar " + eachJarFile.getAbsolutePath() );
 
             files.remove( eachJarFile.getName( ) );
         }


### PR DESCRIPTION
If you want to obfuscate transitive jars from apkibs, one need to add proguard config and use this patch:

<assembly>
                        <inclusions>

```
                        <inclusion>
                            <groupId>name.XXX.android.uploader</groupId>
                            <artifactId>uploader</artifactId>
                            <library>false</library>
                        </inclusion>

                        <inclusion>
                            <groupId>name.XXX.android.YYY</groupId>
                            <artifactId>jsvaluegenerator</artifactId>
                            <library>false</library>
                        </inclusion>

                        <inclusion>
                            <groupId>name.XXX.android.YYY</groupId>
                            <artifactId>voice_commands</artifactId>
                            <library>false</library>
                        </inclusion>

                        <inclusion>
                            <groupId>name.XXX.android.YYY</groupId>
                            <artifactId>valueprovider</artifactId>
                            <library>false</library>
                        </inclusion>

                    </inclusions>
                </assembly>
```

So obfuscated files should be used instead accoring original. Obfuscated jars are located in \target\classes\ folder.

Patched output (checked to be working for my project):

[DEBUG] Searching for obfuscated jars in D:\dev\src\XXX\app\target\classes
[DEBUG] Exclude original jar for obfuscated jar D:\dev\src\XXX\app\target\classes\jsvaluegenerator-1.0.jar
[DEBUG] Exclude original jar for obfuscated jar D:\dev\src\XXX\app\target\classes\uploader-1.0.jar
[DEBUG] Exclude original jar for obfuscated jar D:\dev\src\XXX\app\target\classes\valueprovider-1.0.jar
[DEBUG] Exclude original jar for obfuscated jar D:\dev\src\XXX\app\target\classes\voice_commands-1.0.jar

[DEBUG] Adding jvm argument -Xmx1024M
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\qberticus\simple-quickactions\2.2\simple-quickactions-2.2.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\rhino\js\1.7R2\js-1.7R2.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\android-color-picker\android-color-picker\1.0\android-color-picker-1.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\name\YYY\firmata\Firmata\2.6\Firmata-2.6.jar
[DEBUG] Adding dex input: D:\dev\src\XXX\app\target\classes
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\nineoldandroids\library\2.4.0\library-2.4.0.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\google\code\gson\gson\2.1\gson-2.1.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\lamerman\fileexplorer\1.0\fileexplorer-1.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\android\vending\billing\3.0\billing-3.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\ru\clickwheel\lib\1.0\lib-1.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\org\slf4j\slf4j-android\1.6.1-RC1\slf4j-android-1.6.1-RC1.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\hoho\android\usbserial\1.1\usbserial-1.1.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\name\YYY\android\oscview\1.0\oscview-1.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\google\android\support\4_r11\support-4_r11.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\google\android\apps\analytics\GoogleAnalyticsTracker\2.0\GoogleAnalyticsTracker-2.0.jar
[DEBUG] Adding dex input: D:\dev\src\XXX\meter\target\meter-1.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\name\YYY\android\uploader\service\1.0\service-1.0.apklib
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\com\ftdi\d2xx\1.0\d2xx-1.0.jar
[DEBUG] Adding dex input: C:\Users\sas.m2\repository\name\YYY\firmata\serial\Serial\1.1\Serial-1.1.jar
