### PR TITLE
Only use the Mac OS X JDK-path tweak if the path exists

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -502,10 +502,10 @@ public class ProguardMojo extends AbstractAndroidMojo
             // that is shipped with the SDK (since that is not a complete Java distribution)
             String javaHome = System.getProperty( "java.home" );
             String jdkLibsPath = null;
-            if ( javaHome.startsWith( "/System/Library/Java" ) || javaHome.startsWith( "/Library/Java" ) )
+            if ( isMacOSXJDKbyApple( javaHome ) )
             {
                 // MacOS X uses different naming conventions for JDK installations
-                jdkLibsPath = javaHome + "/../Classes";
+                jdkLibsPath = appleJDKLibsPath( javaHome );
                 addLibraryJar( jdkLibsPath + "/classes.jar" );
             }
             else
@@ -544,6 +544,16 @@ public class ProguardMojo extends AbstractAndroidMojo
         }
     }
 
+    private boolean isMacOSXJDKbyApple( String javaHome )
+    {
+        return ( javaHome.startsWith( "/System/Library/Java" ) || javaHome.startsWith( "/Library/Java" ) )
+                && new File( appleJDKLibsPath( javaHome ) ).exists();
+    }
+
+    private String appleJDKLibsPath( String javaHome )
+    {
+        return javaHome + "/../Classes";
+    }
 
     /**
      * Get the path to the proguard jar.


### PR DESCRIPTION
The new Oracle JVM on Mac OS X doesn't use unconventional paths - only the Apple JVM does. The plugin gives this error when used with the Oracle JVM on Mac OS X:

```
[INFO] java.io.IOException: Can't read [/Library/Java/JavaVirtualMachines/jdk1.7.0_11.jdk/Contents/Home/Classes/classes.jar] (No such file or directory)
[INFO]  at proguard.InputReader.readInput(InputReader.java:230)
[INFO]  at proguard.InputReader.readInput(InputReader.java:200)
[INFO]  at proguard.InputReader.readInput(InputReader.java:178)
[INFO]  at proguard.InputReader.execute(InputReader.java:100)
[INFO]  at proguard.ProGuard.readInput(ProGuard.java:196)
[INFO]  at proguard.ProGuard.execute(ProGuard.java:78)
[INFO]  at proguard.ProGuard.main(ProGuard.java:492)
[INFO] Caused by: java.io.IOException: No such file or directory
[INFO]  at proguard.io.DirectoryPump.pumpDataEntries(DirectoryPump.java:50)
[INFO]  at proguard.InputReader.readInput(InputReader.java:226)
[INFO]  ... 6 more
```

Here's the actual Oracle JVM on Mac OS X:

```
$ ls /Library/Java/JavaVirtualMachines/jdk1.7.0_11.jdk/Contents/Home/Classes/
ls: /Library/Java/JavaVirtualMachines/jdk1.7.0_11.jdk/Contents/Home/Classes/: No such file or directory
$ ls /Library/Java/JavaVirtualMachines/jdk1.7.0_11.jdk/Contents/Home/lib/
ant-javafx.jar      dt.jar          javafx-doclet.jar   jconsole.jar        sa-jdi.jar      visualvm
ct.sym          ir.idl          javafx-mx.jar       orb.idl         tools.jar
$ ls /Library/Java/JavaVirtualMachines/jdk1.7.0_11.jdk/Contents/Home/jre/lib/
JObjC.jar           jli             libjava_crw_demo.dylib      libsaproc.dylib
alt-rt.jar          jsse.jar            libjavafx-font.dylib        libsplashscreen.dylib
applet              jvm.cfg             libjavafx-iio.dylib     libsunec.dylib
calendars.properties        jvm.hprof.txt           libjawt.dylib           libt2k.dylib
charsets.jar            libAppleScriptEngine.dylib  libjdwp.dylib           libunpack.dylib
classlist           libJObjC.dylib          libjfr.dylib            libverify.dylib
cmm             libattach.dylib         libjfxmedia.dylib       libzip.dylib
content-types.properties    libawt.dylib            libjfxwebkit.dylib      logging.properties
currency.data           libdcpr.dylib           libjpeg.dylib           lwawt
deploy.jar          libdecora-sse.dylib     libjsdt.dylib           management
ext             libdeploy.dylib         libjsig.dylib           management-agent.jar
flavormap.properties        libdt_socket.dylib      libjsound.dylib         meta-index
fontconfig.bfc          libfontmanager.dylib        libkcms.dylib           net.properties
fontconfig.properties.src   libglass.dylib          libmanagement.dylib     plugin.jar
fonts               libglib-2.0.0.dylib     libmlib_image.dylib     psfont.properties.ja
fxplugins.dylib         libgstplugins-lite.dylib    libnet.dylib            psfontj2d.properties
headless            libgstreamer-lite.dylib     libnio.dylib            resources.jar
htmlconverter.jar       libhprof.dylib          libnpt.dylib            rt.jar
images              libinstrument.dylib     libosx.dylib            security
javafx.properties       libj2gss.dylib          libosxapp.dylib         server
javaws.jar          libj2pcsc.dylib         libosxkrb5.dylib        servicetag
jce.jar             libj2pkcs11.dylib       libosxui.dylib          sound.properties
jfr.jar             libjaas_unix.dylib      libprism-es2.dylib      xawt
jfxrt.jar           libjava.dylib           librmi.dylib            zi
```
