### PR TITLE
Added the parameter reportSuffix to UIAutomator

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/UIAutomator.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/UIAutomator.java
@@ -40,6 +40,10 @@ public class UIAutomator
      * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.UIAutomatorMojo#createReport}
      */
     private Boolean createReport;
+	/**
+	 * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.UIAutomatorMojo#reportSuffix}
+	 */
+	private String reportSuffix;
     /**
      * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.UIAutomatorMojo#takeScreenshotOnFailure}
      */
@@ -88,6 +92,11 @@ public class UIAutomator
     {
         return createReport;
     }
+
+	public String getReportSuffix()
+	{
+		return reportSuffix;
+	}
 
     public Boolean isTakeScreenshotOnFailure()
     {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UIAutomatorMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UIAutomatorMojo.java
@@ -269,6 +269,21 @@ public class UIAutomatorMojo extends AbstractAndroidMojo
     @PullParameter( defaultValue = "false" )
     private Boolean parsedCreateReport;
 
+	/**
+	 * Adds a suffix to the report name. For example if parameter reportSuffix is "-mySpecialReport",
+	 * the name of the report will be TEST-deviceid-mySpecialReport.xml
+	 *
+	 * Defaults to null. Hence, in the default case, the name of the report will be TEST-deviceid.xml.
+	 *
+	 * @optional
+	 * @parameter expression="${android.uiautomator.reportSuffix}"
+	 *
+	 */
+	private String uiautomatorReportSuffix;
+
+	@PullParameter( required = false, defaultValueGetterMethod = "getReportSuffix" )
+	private String parsedReportSuffix;
+
     /**
      * Decides whether or not to take screenshots when tests execution results in failure or error. Screenshots use the
      * utiliy screencap that is usually available within emulator/devices with SDK >= 16.
@@ -421,6 +436,11 @@ public class UIAutomatorMojo extends AbstractAndroidMojo
         // null if not overriden by configuration
         return parsedTestClassOrMethods;
     }
+
+	private String getReportSuffix()
+	{
+		return parsedReportSuffix;
+	}
 
     /**
      * Helper method to build a comma separated string from a list. Blank strings are filtered out
@@ -884,8 +904,19 @@ public class UIAutomatorMojo extends AbstractAndroidMojo
 
                 FileUtils.forceMkdir( new File( directory ) );
 
-                String fileName = new StringBuilder().append( directory ).append( "/TEST-" )
-                        .append( DeviceHelper.getDescriptiveName( device ) ).append( ".xml" ).toString();
+				StringBuilder sb = new StringBuilder();
+
+				sb.append( directory ).append( "/TEST-" )
+						.append( DeviceHelper.getDescriptiveName( device ) );
+
+				if ( parsedReportSuffix != null && !"".equals(parsedReportSuffix) )
+				{
+					//Safety first
+					sb.append(parsedReportSuffix.replace("/", "").replace("\\", ""));
+				}
+
+				String fileName = sb.append( ".xml" ).toString();
+
                 File reportFile = new File( fileName );
                 writer = new FileWriter( reportFile );
                 Result result = new StreamResult( writer );

--- a/src/test/java/com/jayway/maven/plugins/android/standalonemojos/UIAutomatorMojoTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/standalonemojos/UIAutomatorMojoTest.java
@@ -87,6 +87,8 @@ public class UIAutomatorMojoTest extends AbstractAndroidMojoTestCase< UIAutomato
         String[] automatorTestClassOrMethods = Whitebox.getInternalState( mojo, "parsedTestClassOrMethods" );
         Boolean automatorTakeScreenshotOnFailure = Whitebox.getInternalState( mojo, "parsedTakeScreenshotOnFailure" );
         String automatorScreenshotsPathOnDevice = Whitebox.getInternalState( mojo, "parsedScreenshotsPathOnDevice" );
+		Boolean automatorCreateReport = Whitebox.getInternalState( mojo, "parsedCreateReport" );
+		String automatorReportSuffix = Whitebox.getInternalState( mojo, "parsedReportSuffix" );
 
         assertFalse( "UIAutomator skip parameter should be false", automatorSkip );
         assertFalse( "UIAutomator debug parameter should be false", automatorDebug );
@@ -99,6 +101,8 @@ public class UIAutomatorMojoTest extends AbstractAndroidMojoTestCase< UIAutomato
                 automatorTakeScreenshotOnFailure );
         assertEquals( "UIAutomator screenshotsPath on device be equal /sdcard/uiautomator-screenshots/",
                 "/sdcard/uiautomator-screenshots/", automatorScreenshotsPathOnDevice );
+		assertFalse( "UIAutomator createReport parameter should be false", automatorCreateReport );
+		assertNull( "UIAutomator reportSuffix parameter should be null", automatorReportSuffix );
     }
 
     /**
@@ -135,6 +139,8 @@ public class UIAutomatorMojoTest extends AbstractAndroidMojoTestCase< UIAutomato
         String[] automatorTestClassOrMethods = Whitebox.getInternalState( mojo, "parsedTestClassOrMethods" );
         Boolean automatorTakeScreenshotOnFailure = Whitebox.getInternalState( mojo, "parsedTakeScreenshotOnFailure" );
         String automatorScreenshotsPathOnDevice = Whitebox.getInternalState( mojo, "parsedScreenshotsPathOnDevice" );
+		Boolean automatorCreateReport = Whitebox.getInternalState( mojo, "parsedCreateReport" );
+		String automatorReportSuffix = Whitebox.getInternalState( mojo, "parsedReportSuffix" );
 
         assertFalse( "UIAutomator skip parameter should be false", automatorSkip );
         assertFalse( "UIAutomator debug parameter should be false", automatorDebug );
@@ -152,6 +158,10 @@ public class UIAutomatorMojoTest extends AbstractAndroidMojoTestCase< UIAutomato
                 automatorTakeScreenshotOnFailure );
         assertEquals( "UIAutomator screenshotsPath on device be equal /mnt/sdcard/screenshots/",
                 "/mnt/sdcard/screenshots/", automatorScreenshotsPathOnDevice );
+		assertTrue( "UIAutomator createReport parameter should be true", automatorCreateReport );
+		String expectedReportSuffix = "-mySpecialReport";
+		assertEquals( "UIAutomator reportSuffix parameter should be equal to "+expectedReportSuffix,
+				expectedReportSuffix, automatorReportSuffix );
     }
 
 }

--- a/src/test/resources/ui-automator-config-project2/plugin-config.xml
+++ b/src/test/resources/ui-automator-config-project2/plugin-config.xml
@@ -18,6 +18,7 @@
                             <testClassOrMethod>b#c</testClassOrMethod>
                         </testClassOrMethods>
                         <createReport>true</createReport>
+						<reportSuffix>-mySpecialReport</reportSuffix>
                         <takeScreenshotOnFailure>true</takeScreenshotOnFailure>
                         <screenshotsPathOnDevice>/mnt/sdcard/screenshots/</screenshotsPathOnDevice>
                     </uiautomator>


### PR DESCRIPTION
I added the parameter reportSuffix to the UIAutomator mojo. This makes it possible for the user to run two consecutive uiautomator tests without losing the first result xml. 

I did not want to have the parameter to set the name of the report completely (something like surefire's outputName). This is because if you run mvn surefire-report:report it will try to find all documents in target/surefire-reports/ that are named TEST-*.xml. The suffix parameter will therefore help the user not making any mistakes. 

I also changed the unit tests of UIAutomator to reflect the new parameter.
