### PR TITLE
--non-constant-id for generating R for APKLIBs

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -427,6 +427,10 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
 
         List<String> commands = new ArrayList<String>();
         commands.add( "package" );
+        if ( APKLIB.equals( project.getArtifact().getType() ) )
+        {
+            commands.add( "--non-constant-id" );
+        }
         commands.add( "-m" );
         commands.add( "-J" );
         commands.add( genDirectory.getAbsolutePath() );


### PR DESCRIPTION
Adds the `--non-constant-id` flag to aapt when generating the R.class for
APKLIBs to give non-final ints. This is additional to the fix by xian
which was only doing this in `generateRForApkLibDependency` method - this
change does it in the `generateR` method as well but only for APKLIBs.

This is necessary for when you want to make an apklib that has your source
as a .jar but also contain some XML resource files. It doesn't fix [Issue
313](https://code.google.com/p/maven-android-plugin/issues/detail?id=313) but it basically allows you to do what the person who raised it
wanted.

**Note:** I tried doing a `mvn clean install` on the sample project (first without my change) and I could everything to except the `mixed-java-native-with-apklib-dependency` module in the `native` samples. By skipping this module it built fine and also then built fine with my change. I do confess to being quite new to both Maven and Git/GitHub so I'll apologise now if I've done anything obviously stupid!
