### PR TITLE
Support manifest merger with Android SDK R22

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergerInitializerFactory.java
+++ b/src/main/java/com/jayway/maven/plugins/android/manifmerger/MergerInitializerFactory.java
@@ -17,14 +17,10 @@ public class MergerInitializerFactory
      * Constant for SDK Tools R20
      */
     private static final int R20 = 20;
-    /**
-     * Constant for SDK Tools R21
-     */
-    private static final int R21 = 21;
 
     /**
      * Returns the MergeStrategy for the specified version of the SDK Tools.
-     * Currently supports Revisions: 20, 21.
+     * Currently supports Android SDK 20+.
      * 
      * @param log The Mojo Log
      * @param sdkMajorVersion The major version of the SDK Tools
@@ -35,17 +31,15 @@ public class MergerInitializerFactory
     public static MergeStrategy getInitializer( Log log, int sdkMajorVersion, File sdkPath )
             throws MojoExecutionException
     {
-        switch ( sdkMajorVersion )
-        {
-        case R20:
+        if ( sdkMajorVersion < R20 ) {
+            throw new MojoExecutionException("Manifest merger requires Android SDK " + R20 +
+                    " or greater, but Android SDK " + sdkMajorVersion + " is in use.");
+        }
+
+        if ( sdkMajorVersion == R20 ) {
             return new MergeStrategyR20( log, sdkPath );
-        case R21:
+        } else {
             return new MergeStrategyR21( log, sdkPath );
-        default:
-          log.info( "ATTENTION! Your Android SDK is outdated and not supported for the AndroidManifest merge feature" );
-          log.info( "Supported major versions are " + R20 + " and " + R21 + ". You are using " + sdkMajorVersion );
-          log.info( "Execution proceeding using merge procedure from " + R20 );
-          return new MergeStrategyR20( log, sdkPath );
         }
     }
 }


### PR DESCRIPTION
Fixes the following build error when using R22 (or later versions):

```
[INFO] Getting manifests of dependent apklibs
[INFO] ATTENTION! Your Android SDK is outdated and not supported for the AndroidManifest merge feature
[INFO] Supported major versions are 20 and 21. You are using 22
[INFO] Execution proceeding using merge procedure from 20
[ERROR] Cannot find required class
java.lang.ClassNotFoundException: com.android.sdklib.StdSdkLog
    at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
    at com.jayway.maven.plugins.android.manifmerger.MergeStrategyR20.<init>(MergeStrategyR20.java:71)
    at com.jayway.maven.plugins.android.manifmerger.MergerInitializerFactory.getInitializer(MergerInitializerFactory.java:48)
    at com.jayway.maven.plugins.android.manifmerger.ManifestMerger.initialize(ManifestMerger.java:41)
    at com.jayway.maven.plugins.android.manifmerger.ManifestMerger.<init>(ManifestMerger.java:51)
    at com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.mergeManifests(GenerateSourcesMojo.java:556)
    at com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.execute(GenerateSourcesMojo.java:192)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
[ERROR] Error when generating sources.
org.apache.maven.plugin.MojoExecutionException: Cannot find the required class
    at com.jayway.maven.plugins.android.manifmerger.MergeStrategyR20.<init>(MergeStrategyR20.java:82)
    at com.jayway.maven.plugins.android.manifmerger.MergerInitializerFactory.getInitializer(MergerInitializerFactory.java:48)
    at com.jayway.maven.plugins.android.manifmerger.ManifestMerger.initialize(ManifestMerger.java:41)
    at com.jayway.maven.plugins.android.manifmerger.ManifestMerger.<init>(ManifestMerger.java:51)
    at com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.mergeManifests(GenerateSourcesMojo.java:556)
    at com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.execute(GenerateSourcesMojo.java:192)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: java.lang.ClassNotFoundException: com.android.sdklib.StdSdkLog
    at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
    at com.jayway.maven.plugins.android.manifmerger.MergeStrategyR20.<init>(MergeStrategyR20.java:71)
    ... 26 more
```
