### PR TITLE
Fix for zipalign tool

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AndroidSdk.java
@@ -211,7 +211,7 @@ public class AndroidSdk
      */
     public String getZipalignPath()
     {
-        return getPathForPlatformTool( SdkConstants.FN_ZIPALIGN );
+        return getPathForTool( SdkConstants.FN_ZIPALIGN );
     }
 
     /**


### PR DESCRIPTION
On windows at least zipalign is in tools and not platform-tools

Could someone test this on Linux? os x?
