### PR TITLE
Re-enabled aapt --debug-mode

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -1095,7 +1095,7 @@ public class ApkMojo extends AbstractAndroidMojo
             getLog().info( "Enabling debug build for apk." );
 // @mosabua : this no longer works with R22 of the SDK so we are removing it going forward. Just commented out for now 
 // in case there is some replacement, at first glance I could not see anything            
-//            commands.add( "--debug-mode" );
+            commands.add( "--debug-mode" );
         }
         else 
         {


### PR DESCRIPTION
It still works on windows on an andorid-sdk 22 (updated from 21.1)

Can someone test it on linux? os ox?
