### PR TITLE
aidl generation: Use `artifact.getId()` to avoid namespace colllisions

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -187,7 +187,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 {
                     apklibAidlFiles = findRelativeAidlFileNames(
                             new File( getLibraryUnpackDirectory( artifact ) + "/src" ) );
-                    relativeApklibAidlFileNames.put( artifact.getArtifactId(), apklibAidlFiles );
+                    relativeApklibAidlFileNames.put( artifact.getId(), apklibAidlFiles );
                 }
             }
 
@@ -208,7 +208,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 if ( artifact.getType().equals( APKLIB ) )
                 {
                     files.put( new File( getLibraryUnpackDirectory( artifact ) + "/src" ),
-                            relativeApklibAidlFileNames.get( artifact.getArtifactId() ) );
+                            relativeApklibAidlFileNames.get( artifact.getId() ) );
                 }
             }
             generateAidlFiles( files );


### PR DESCRIPTION
The previously used `artifact.getArtifactId()` is not guaranteed
to be unique - two apklibs with the same artifact id (e.g. 'library')
will overwrite their configuration.
