### PR TITLE
add possibility to generate final ints in R

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -161,7 +161,15 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
      * default-value="${project.build.directory}/generated-sources/aidl"
      */
     protected File genDirectoryAidl;
-    
+
+    /**
+     * Generate final ints in R for apklib
+     *
+     * @parameter
+     */
+    protected boolean generateFinalIntsInR;
+
+
     public void execute() throws MojoExecutionException, MojoFailureException
     {
 
@@ -429,7 +437,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
 
         List<String> commands = new ArrayList<String>();
         commands.add( "package" );
-        if ( APKLIB.equals( project.getArtifact().getType() ) )
+        if ( APKLIB.equals( project.getArtifact().getType() ) && !generateFinalIntsInR )
         {
             commands.add( "--non-constant-id" );
         }
@@ -609,7 +617,10 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
 
         List<String> commands = new ArrayList<String>();
         commands.add( "package" );
-        commands.add( "--non-constant-id" );
+        if ( !generateFinalIntsInR )
+        {
+            commands.add( "--non-constant-id" );
+        }
         commands.add( "-m" );
         commands.add( "-J" );
         commands.add( genDirectory.getAbsolutePath() );


### PR DESCRIPTION
By default plugin generate non final ints in R of apklib, it makes impossible to write code like this: @InjectView(R.id.login_pin) private EditText pinField;

I have added configuration flag for default behavior overriding.
