### PR TITLE
Custom BuildConfig constants from the plugin configuration

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/BuildConfigConstant.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/BuildConfigConstant.java
@@ -1,0 +1,51 @@
+package com.jayway.maven.plugins.android.configuration;
+
+/**
+ * Configuration for a custom BuildConfig constant.
+ *
+ * @author jonasfa@gmail.com
+ */
+public class BuildConfigConstant
+{
+    /**
+     * Name of the constant.
+     * Eg.: SERVER_URL, etc
+     *
+     * @parameter expression="{android.buildConfigConstants[].name}"
+     * @required
+     */
+    private String name;
+
+    /**
+     * Type of the value.
+     * Eg.: String, int, com.mypackage.MyType, etc
+     *
+     * @parameter expression="{android.buildConfigConstants[].type}"
+     * @required
+     */
+    private String type;
+
+    /**
+     * Value of the constant.
+     * Eg.: MyString, 123, new com.mypackage.MyType(), etc
+     *
+     * @parameter expression="{android.buildConfigConstants[].value}"
+     * @required
+     */
+    private String value;
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -24,6 +24,7 @@ import com.jayway.maven.plugins.android.CommandExecutor;
 import com.jayway.maven.plugins.android.ExecutionException;
 import com.jayway.maven.plugins.android.common.AetherHelper;
 
+import com.jayway.maven.plugins.android.configuration.BuildConfigConstant;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
@@ -161,7 +162,15 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
      * default-value="${project.build.directory}/generated-sources/aidl"
      */
     protected File genDirectoryAidl;
-    
+
+    /**
+     * <p>Parameter designed to generate custom BuildConfig constants
+     *
+     * @parameter expression="${android.buildConfigConstants}"
+     * @readonly
+     */
+    protected BuildConfigConstant[] buildConfigConstants;
+
     public void execute() throws MojoExecutionException, MojoFailureException
     {
 
@@ -698,16 +707,34 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
     {
         File outputFolder = new File( genDirectory, packageName.replace( ".", File.separator ) );
         outputFolder.mkdirs();
-        String buildConfig = ""
-                + "package " + packageName + ";\n\n"
-                + "public final class BuildConfig {\n"
-                + "  public static final boolean DEBUG = " + Boolean.toString( !release ) + ";\n"
-                + "}\n"
-        ;
+
+        StringBuilder buildConfig = new StringBuilder();
+        buildConfig.append( "package " ).append( packageName ).append( ";\n\n" );
+        buildConfig.append( "public final class BuildConfig {\n" );
+        buildConfig.append( "  public static final boolean DEBUG = " ).append( !release ).append( ";\n" );
+        for ( BuildConfigConstant constant : buildConfigConstants )
+        {
+            String value = constant.getValue();
+            if ( "String".equals( constant.getType() ) )
+            {
+                value = "\"" + value + "\"";
+            }
+
+            buildConfig.append( "  public static final " )
+                       .append( constant.getType() )
+                       .append( " " )
+                       .append( constant.getName() )
+                       .append( " = " )
+                       .append( value )
+                       .append( ";\n" );
+        }
+        buildConfig.append( "}\n" );
+
+
         File outputFile = new File( outputFolder, "BuildConfig.java" );
         try
         {
-            FileUtils.writeStringToFile( outputFile, buildConfig );
+            FileUtils.writeStringToFile( outputFile, buildConfig.toString() );
         }
         catch ( IOException e )
         {


### PR DESCRIPTION
https://groups.google.com/forum/?fromgroups#!topic/maven-android-developers/ZvFtLNufSXU

This plugin configuration:

```
<configuration>
    <buildConfigConstants>
        <constant>
            <name>TEST_NUMBER</name>
            <type>int</type>
            <value>123</value>
        </constant>
        <constant>
            <name>SERVER</name>
            <type>String</type>
            <value>http://app-staging.herokuap.com</value>
        </constant>
    </buildConfigConstants>
</configuration>
```

Generates the following BuildConfig.java:

```
package app.package;

public final class BuildConfig {
  public static final boolean DEBUG = true;
  public static final int TEST_NUMBER = 123;
  public static final String SERVER = "http://app-staging.herokuap.com";
}
```
