### PR TITLE
NDK mojo: ignore libs/ folder with just JARs for APKLIB dependencies

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
@@ -1,5 +1,6 @@
 package com.jayway.maven.plugins.android.common;
 
+import com.google.common.io.PatternFilenameFilter;
 import com.jayway.maven.plugins.android.AbstractAndroidMojo;
 import com.jayway.maven.plugins.android.AndroidNdk;
 import com.jayway.maven.plugins.android.phase09package.ApklibMojo;
@@ -176,7 +177,9 @@ public class NativeHelper
                         // Check if the artifact contains a libs folder - if so, include it in the list
                         File libsFolder = new File(
                                 AbstractAndroidMojo.getLibraryUnpackDirectory( unpackDirectory, artifact ) + "/libs" );
-                        if ( libsFolder.exists() )
+                        // make sure we ignore libs folders that only contain JARs
+                        if ( libsFolder.exists()
+                                && libsFolder.list( new PatternFilenameFilter( ".+[^.jar]$" ) ).length > 0 )
                         {
                             log.debug( "Including attached artifact: " + artifact.getArtifactId() 
                                     + "(" + artifact.getGroupId() + "). Artifact is APKLIB." );

--- a/src/test/java/com/jayway/maven/plugins/android/common/NativeHelperTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/common/NativeHelperTest.java
@@ -1,13 +1,57 @@
 package com.jayway.maven.plugins.android.common;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.DefaultArtifactFactory;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.testing.SilentLog;
+import org.apache.maven.plugin.testing.stubs.ArtifactStub;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.sonatype.aether.impl.internal.DefaultRepositorySystem;
+import org.sonatype.aether.repository.RemoteRepository;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * @author Johan Lindquist
  */
 public class NativeHelperTest {
+
+    @Rule
+    public TemporaryFolder apklibDir = new TemporaryFolder();
+
+    private NativeHelper nativeHelper;
+
+    @Before
+    public void setupNativeHelper() {
+        MavenProject project = new MavenProject();
+        project.setDependencyArtifacts(Collections.<Artifact>emptySet());
+
+        ArtifactStub apklib = new ArtifactStub() {
+            @Override
+            public String getId() {
+                return getArtifactId();
+            }
+        };
+        apklib.setArtifactId("some-apklib");
+        apklib.setGroupId("group");
+        apklib.setType(AndroidExtension.APKLIB);
+        project.addAttachedArtifact(apklib);
+
+        nativeHelper = new NativeHelper(project, Collections.<RemoteRepository>emptyList(),
+                new MavenRepositorySystemSession(), new DefaultRepositorySystem(),
+                new DefaultArtifactFactory(), new SilentLog());
+    }
 
     @Test
     public void invalidVersions()
@@ -32,12 +76,31 @@ public class NativeHelperTest {
         for (int i = 0; i < versions.length; i++) {
             String version = versions[i];
             try {
-                NativeHelper.validateNDKVersion(7,version);
+                NativeHelper.validateNDKVersion(7, version);
             } catch (MojoExecutionException e) {
                 Assert.fail("Version should not fail: " + version);
             }
         }
     }
 
+    @Test
+    public void shouldNotIncludeLibsFolderAsNativeDependenciesSourceWhenNoNativeLibsInside() throws Exception {
+        new File(apklibDir.getRoot(), "some-apklib/libs").mkdirs();
+        new File(apklibDir.getRoot(), "some-apklib/libs/some.jar").createNewFile();
 
+        Set<Artifact> nativeDependencies = nativeHelper.getNativeDependenciesArtifacts(apklibDir.getRoot(), true);
+
+        assertTrue("Included JARs as native dependencies, but shouldn't", nativeDependencies.isEmpty());
+    }
+
+    @Test
+    public void shouldIncludeLibsFolderAsNativeDependenciesSourceWhenNativeLibsInside() throws Exception {
+        new File(apklibDir.getRoot(), "some-apklib/libs").mkdirs();
+        new File(apklibDir.getRoot(), "some-apklib/libs/some.jar").createNewFile();
+        new File(apklibDir.getRoot(), "some-apklib/libs/some.so").createNewFile();
+
+        Set<Artifact> nativeDependencies = nativeHelper.getNativeDependenciesArtifacts(apklibDir.getRoot(), true);
+
+        assertFalse("Excluded native dependencies, but shouldn't", nativeDependencies.isEmpty());
+    }
 }


### PR DESCRIPTION
This should fix https://code.google.com/p/maven-android-plugin/issues/detail?id=402

Can someone review please? This was a show stopper for us, since it broke all NDK builds with apklib dependencies with libs/ folders containing JARs (which is perfectly fine to have, libs/ is not exclusive to native libraries.)

What this change accomplishes is simply ignoring the libs/ folder whenever it only contains JAR files.

I couldn't actually test this with a project that actually has an apklib dependency with native libraries in libs/. Would be good if someone who needs that functionality can verify it's still working.
