### PR TITLE
o use maven 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
        -->
         <maven-plugin-plugin.version>2.8</maven-plugin-plugin.version>
 
-        <maven.api.version>3.1.0-alpha-1</maven.api.version>
+        <maven.api.version>3.1.0</maven.api.version>
         <easymock.version>3.1</easymock.version>
         <powermock.version>1.5</powermock.version>
         <aether.version>0.9.0.M2</aether.version>
@@ -106,6 +106,13 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- Use this to force sisu's version of ASM which is causing a problem. Will be fixed in Maven 3.1.1 -->
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.plexus</artifactId>
+            <version>0.0.0.M4</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
o force the use of sisu's ASM (to avoid a conflict in testing)
o use new plugin testing tools which have been updated for maven 3.1.0 (to avoid aether conflicts)
