### PR TITLE
Support for maven property maven.test.error.ignore

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -1097,7 +1097,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
         {
             if ( mavenIgnoreTestFailure && mavenIgnoreTestError )
             {
-                return true;
+                return false;
             }
 
             if ( mavenIgnoreTestFailure )


### PR DESCRIPTION
Hi Manfred,

a small change to allow to ignore errors in android tests. Failures could already be ignored but not errors.

Thx for your work,
 S.
