### PR TITLE
Support for multiarch so dependencies

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase05compile/MakefileHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase05compile/MakefileHelper.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -158,6 +159,12 @@ public class MakefileHelper
             {
                 boolean apklibStatic = false;
 
+                if ( artifact.hasClassifier() )
+                {
+                    makeFile.append( '\n' );
+                    makeFile.append( "ifeq ($(TARGET_ARCH_ABI)," ).append( artifact.getClassifier() ).append( ")\n" );
+                }
+
                 makeFile.append( "#\n" );
                 makeFile.append( "# Group ID: " );
                 makeFile.append( artifact.getGroupId() );
@@ -228,6 +235,12 @@ public class MakefileHelper
                 else
                 {
                     makeFile.append( "include $(PREBUILT_SHARED_LIBRARY)\n" );
+                }
+
+                if ( artifact.hasClassifier() )
+                {
+                    makeFile.append( "endif #" ).append( artifact.getClassifier() ).append( '\n' );
+                    makeFile.append( '\n' );
                 }
             }
         }


### PR DESCRIPTION
This pull request makes multiple so dependencies with different classifiers work correctly. So, you could have a dependency with classifier=armeabi, and the same dependency with classifier=x86 in the same project.

There are two major changes:
1. We drop duplicate library names when generating LOCAL_STATIC_LIBRARIES and LOCAL_SHARED_LIBRARIES
2. We ignore native libs that do not match current TARGET_ARCH_ABI

These two changes should guarantee that correct libraries will be used when APP_ABI is set in Application.mk to contain multiple entries.

**Note! Multiarch apklibs are not 100% working yet, but these changes should not break any existing functionality**
