### PR TITLE
Make use of "aaptExtraArgs" in "generate-sources" goal.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -544,6 +544,12 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
             commands.add( "-c" );
             commands.add( configurations );
         }
+
+        for ( String aaptExtraArg : aaptExtraArgs )
+        {
+            commands.add( aaptExtraArg );
+        }
+
         if ( proguardFile != null )
         {
             File parentFolder = proguardFile.getParentFile();
@@ -739,6 +745,12 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
             commands.add( "-c" );
             commands.add( configurations );
         }
+
+        for ( String aaptExtraArg : aaptExtraArgs )
+        {
+            commands.add( aaptExtraArg );
+        }
+
         getLog().info( getAndroidSdk().getAaptPath() + " " + commands.toString() );
         try
         {


### PR DESCRIPTION
Sometimes, there is a use-case in which we need to have static fields in "R.java" to not be public, even in the APK. Right now there's no way to achieve this behavior and using the aaptExtraArgs seems a right way to do it. Also, that's why the aaptExtraArgs is there right?
