### PR TITLE
[travis-ci] Download, install and use Maven 3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ before_install:
   - export ANDROID_HOME=$PWD/android-sdk-linux
   - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
 
+  # Maven 3.1.1
+  - wget http://www.us.apache.org/dist/maven/maven-3/3.1.1/binaries/apache-maven-3.1.1-bin.tar.gz
+  - tar xvf apache-maven-3.1.1-bin.tar.gz > /dev/null
+  - export MVN_HOME=`pwd`/apache-maven-3.1.1
+  - export PATH=${MVN_HOME}/bin/:${PATH}
+  - mvn --version
+
   # Install required components.
   # For a full list, run `android list sdk -a --extended`
   # Note that sysimg-16 downloads the ARM, x86 and MIPS images (we should optimize this).


### PR DESCRIPTION
There is no reason for red build while waiting for Travis CI team to
make Maven 3.1.1 available out of the box.

Signed-off-by: Mykola Nikishov mn@mn.com.ua
