### PR TITLE
extended instrumentation goal to allow for additional user defined instrumentation arguments

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -127,6 +127,9 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
      *   &lt;packages&gt;
      *     &lt;package&gt;your.package.name&lt;/package&gt;
      *   &lt;/packages&gt;
+     *   &lt;instrumentationArgs&gt;
+     *     &lt;instrumentationArg&gt;key value&lt;/instrumentationArg&gt;
+     *   &lt;/instrumentationArgs&gt;
      * &lt;/test&gt;
      * </pre>
      *
@@ -292,6 +295,21 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
      */
     protected List<String> testExcludeAnnotations;
 
+    /**
+     * <p>Extra instrumentation arguments.</p>
+     * <pre>
+     * &lt;instrumentationArgs&gt;
+     *     &lt;instrumentationArg&gt;key value&lt;/instrumentationArg&gt;
+     *     &lt;instrumentationArg&gt;key 'value with spaces'&lt;/instrumentationArg&gt;
+     * &lt;/instrumentationArgs&gt;
+     * </pre>
+     * or as e.g. -Dandroid.test.instrumentationArgs="key1 value1","key2 'value with spaces'"
+     *
+     * @optional
+     * @parameter expression="${android.test.instrumentationArgs}"
+     */
+    protected List<String> testInstrumentationArgs;
+
     private boolean classesExists;
     private boolean packagesExists;
 
@@ -303,6 +321,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
     private List<String> parsedPackages;
     private List<String> parsedAnnotations;
     private List<String> parsedExcludeAnnotations;
+    private Map<String, String> parsedInstrumentationArgs;
     private String parsedTestSize;
     private Boolean parsedCoverage;
     private String parsedCoverageFile;
@@ -405,6 +424,8 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
                     remoteAndroidTestRunner.setTestSize( validSize );
                 }
 
+                addAllInstrumentationArgs( remoteAndroidTestRunner, parsedInstrumentationArgs );
+
                 getLog().info( deviceLogLinePrefix +  "Running instrumentation tests in " 
                         + parsedInstrumentationPackage );
                 try
@@ -447,6 +468,16 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
         instrumentationTestExecutor = new ScreenshotServiceWrapper( instrumentationTestExecutor, project, getLog() );
 
         doWithDevices( instrumentationTestExecutor );
+    }
+
+    private void addAllInstrumentationArgs(
+            final RemoteAndroidTestRunner remoteAndroidTestRunner,
+            final Map<String, String> parsedInstrumentationArgs )
+    {
+        for ( final Map.Entry<String, String> entry : parsedInstrumentationArgs.entrySet() )
+        {
+            remoteAndroidTestRunner.addInstrumentationArg( entry.getKey(), entry.getValue() );
+        }
     }
 
     private void parseConfiguration()
@@ -558,6 +589,8 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
             {
                 parsedCreateReport = testCreateReport;
             }
+
+            parsedInstrumentationArgs = InstrumentationArgumentParser.parse( test.getInstrumentationArgs() );
         }
         // no pom, we take properties
         else
@@ -575,6 +608,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
             parsedDebug = testDebug;
             parsedLogOnly = testLogOnly;
             parsedCreateReport = testCreateReport;
+            parsedInstrumentationArgs = InstrumentationArgumentParser.parse( testInstrumentationArgs );
         }
     }
 

--- a/src/main/java/com/jayway/maven/plugins/android/InstrumentationArgumentParser.java
+++ b/src/main/java/com/jayway/maven/plugins/android/InstrumentationArgumentParser.java
@@ -1,0 +1,67 @@
+package com.jayway.maven.plugins.android;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>Parses a list of key/value pairs separated by a space in to a map.</p>
+ *
+ * <p>Example input:</p>
+ * <pre>
+ *     list[0] = "firstKey firstValue"
+ *     list[1] = "secondKey 'second value with space and single quote escape'
+ * </pre>
+ *
+ * <p>Example output:</p>
+ * <pre>
+ *     map["firstKey"] = "firstValue"
+ *     map["secondKey"] = "'second value with space and single quote escape'"
+ * </pre>
+ */
+public class InstrumentationArgumentParser
+{
+    private static final String SEPARATOR = " ";
+
+    /**
+     * Parses the given {@code flatArgs} into a map of key/value pairs.
+     *
+     * @param flatArgs the flat representation of arguments, might be null
+     * @return a map representation of the given key/value pair list, might be empty
+     * @throws IllegalArgumentException when the given list contains unparseable entries
+     */
+    public static Map<String, String> parse( final List<String> flatArgs )
+    {
+        if ( flatArgs == null )
+        {
+            return Collections.EMPTY_MAP;
+        }
+
+        final Map<String, String> mappedArgs = new HashMap<String, String>();
+
+        for ( final String flatArg : flatArgs )
+        {
+            final AbstractMap.SimpleEntry<String, String> keyValuePair = parseKeyValuePair( flatArg );
+            mappedArgs.put( keyValuePair.getKey(), keyValuePair.getValue() );
+        }
+
+        return mappedArgs;
+    }
+
+    private static AbstractMap.SimpleEntry<String, String> parseKeyValuePair( final String arg )
+    {
+        final List<String> keyValueSplit = Lists.newArrayList( Splitter.on( SEPARATOR ).limit( 2 ).split( arg ) );
+
+        if ( keyValueSplit.size() == 1 )
+        {
+            throw new IllegalArgumentException( "Could not separate \"" + arg + "\" by a whitespace into two parts" );
+        }
+
+        return new AbstractMap.SimpleEntry<String, String>( keyValueSplit.get( 0 ), keyValueSplit.get( 1 ) );
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Test.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Test.java
@@ -63,6 +63,10 @@ public class Test
      * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testExcludeAnnotations}
      */
     private List<String> excludeAnnotations;
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.AbstractInstrumentationMojo#testInstrumentationArgs}
+     */
+    private List<String> instrumentationArgs;
 
     public String getSkip()
     {
@@ -127,5 +131,10 @@ public class Test
     public List<String> getExcludeAnnotations()
     {
         return excludeAnnotations;
+    }
+
+    public List<String> getInstrumentationArgs()
+    {
+        return instrumentationArgs;
     }
 }

--- a/src/test/java/com/jayway/maven/plugins/android/InstrumentationArgumentParserTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/InstrumentationArgumentParserTest.java
@@ -1,0 +1,64 @@
+package com.jayway.maven.plugins.android;
+
+import com.google.common.collect.Lists;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class InstrumentationArgumentParserTest
+{
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void should_return_an_empty_map_for_null_list()
+    {
+        assertTrue( InstrumentationArgumentParser.parse( null ).isEmpty() );
+    }
+
+    @Test
+    public void two_flat_args_should_be_parsed_into_two_key_value_pairs()
+    {
+        final List<String> flatArgs = Lists.newArrayList( "key1 value1", "key2 value2" );
+        final Map<String,String> parsedArgs = InstrumentationArgumentParser.parse( flatArgs );
+
+        assertThat( parsedArgs.get( "key1" ), is( "value1" ) );
+        assertThat( parsedArgs.get( "key2" ), is( "value2" ) );
+    }
+
+    @Test
+    public void should_parse_values_with_space_character()
+    {
+        final List<String> flatArgs = Lists.newArrayList( "key1 'value with spaces'" );
+        final Map<String,String> parsedArgs = InstrumentationArgumentParser.parse( flatArgs );
+
+        assertThat( parsedArgs.get( "key1" ), is( "'value with spaces'" ) );
+    }
+
+    @Test
+    public void missing_value_should_throw_IllegalArgumentException()
+    {
+        expectedException.expect( IllegalArgumentException.class );
+        expectedException.expectMessage( is( "Could not separate \"key1\" by a whitespace into two parts" ) );
+
+        final List<String> flatArgs = Lists.newArrayList( "key1" );
+        InstrumentationArgumentParser.parse( flatArgs );
+    }
+
+    @Test
+    public void empty_pair_should_throw_IllegalArgumentException()
+    {
+        expectedException.expect( IllegalArgumentException.class );
+        expectedException.expectMessage( is( "Could not separate \"\" by a whitespace into two parts" ) );
+
+        final List<String> flatArgs = Lists.newArrayList( "" );
+        InstrumentationArgumentParser.parse( flatArgs );
+    }
+}


### PR DESCRIPTION
I was a little unsure on how to test my extension of the `AbstractInstrumentationMojo`, so I kept the changes to a minimum there and extracted the actual "parsing" to a separate `InstrumentationArgumentParser` class, which is unit tested completely.

I would be happy to also throw in some coverage for the `AbstractInstrumentationMojo`, but it seems that there is no real unit test setup yet. I guess some refactoring might be involved to make this component testable.

Any ideas/suggestions?

Also I would like to have some feedback about the way I merge in the customer defined arguments, because the user is now able to override plugin defined configurations manually.
