### PR TITLE
Support aar consumption

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -39,7 +39,6 @@ import com.jayway.maven.plugins.android.ExecutionException;
 import com.jayway.maven.plugins.android.configuration.Dex;
 import com.jayway.maven.plugins.android.phase04processclasses.ProguardMojo;
 
-import static com.jayway.maven.plugins.android.common.AndroidExtension.AAR;
 
 
 /**
@@ -200,15 +199,7 @@ public class DexMojo extends AbstractAndroidMojo
             inputs.add( new File( project.getBuild().getOutputDirectory() ) );
             for ( Artifact artifact : getAllRelevantDependencyArtifacts() )
             {
-                if ( artifact.getType().equals( AAR ) )
-                {
-                    final String apkLibResDir = getLibraryUnpackDirectory( artifact ) + "/classes.jar";
-                    if ( new File( apkLibResDir ).exists() )
-                    {
-                        inputs.add( new File( apkLibResDir ) );
-                    }
-                }
-                else if ( artifact.getType().equals( "so" ) || artifact.getType().equals( "a" ) )
+               if ( artifact.getType().equals( "so" ) || artifact.getType().equals( "a" ) )
                 {
                     // Ignore native dependencies - no need for dexer to see those
                     continue;


### PR DESCRIPTION
I missed a pull request from https://github.com/ialbors which fixes aar consumption.

Basically when I implemented aar consumption I was preparing the dex phase to consume the classes from the classes.jar
But then the compile phase didn't work since it didn't know the classes.jar
So we implemented a kind of ugly solution to show the classes to the compile phase which broke the dex code I added before.

Credits goes to https://github.com/ialbors
