### PR TITLE
Describe duplicate file error

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -619,7 +619,9 @@ public class ApkMojo extends AbstractAndroidMojo
         } 
         catch ( DuplicateFileException e )
         {
-            throw new MojoExecutionException( e.getMessage() );
+            final String msg = String.format("Duplicate file! archive: %s, file1: %s, file2: %s",
+                    e.getArchivePath(), e.getFile1(), e.getFile2());
+            throw new MojoExecutionException( msg, e );
         } 
         catch ( SealedApkException e )
         {


### PR DESCRIPTION
This one saved me much time when I had duplicate files in min dependencies.

Original message was: 

> MojoExecutionException: Duplicate files at the same path inside the APK`

With this update I got the following message:

> MojoExecutionException: Duplicate file! archivePath: LICENSE.txt, file1: /home/me/project/android/module_a/target/classes/LICENSE.txt, file2: /home/me/project/android/module_b/target/module_b-x.y.z.jar`
