### PR TITLE
Give the possibility to set a list of device

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -26,13 +26,11 @@ import com.jayway.maven.plugins.android.common.DeviceHelper;
 import com.jayway.maven.plugins.android.config.ConfigPojo;
 import com.jayway.maven.plugins.android.configuration.Ndk;
 import com.jayway.maven.plugins.android.configuration.Sdk;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.JXPathNotFoundException;
 import org.apache.commons.jxpath.xml.DocumentContainer;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.execution.MavenSession;
@@ -58,6 +56,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.jayway.maven.plugins.android.common.AndroidExtension.APK;
@@ -252,6 +251,17 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      * @parameter expression="${android.device}"
      */
     protected String device;
+
+    /**
+     * Specifies which the serial number of each device to connect to. Using the special values "usb" or
+     * "emulator" is also valid. "usb" will connect to all actual devices connected (via usb). "emulator" will
+     * connect to all emulators connected. Multiple devices will be iterated over in terms of goals to run. All
+     * device interaction goals support this so you can e.. deploy the apk to all attached emulators and devices.
+     * Goals supporting this are devices, deploy, undeploy, redeploy, pull, push and instrument.
+     *
+     * @parameter expression="${android.devices}"
+     */
+    protected String[] devices;
 
     /**
      * A selection of configurations to be included in the APK as a comma separated list. This will limit the
@@ -750,14 +760,14 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
             throw new MojoExecutionException( "No online devices attached." );
         }
 
-        boolean shouldRunOnAllDevices = StringUtils.isBlank( device );
+        boolean shouldRunOnAllDevices = getDevices().size() == 0;
         if ( shouldRunOnAllDevices )
         {
-            getLog().info( "android.device parameter not set, using all attached devices" );
+            getLog().info( "android.devices parameter not set, using all attached devices" );
         }
         else
         {
-            getLog().info( "android.device parameter set to " + device );
+            getLog().info( "android.devices parameter set to " + getDevices().toString() );
         }
 
         ArrayList<DoThread> doThreads = new ArrayList<DoThread>();
@@ -786,7 +796,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
 
         if ( ! shouldRunOnAllDevices && doThreads.isEmpty() )
         {
-            throw new MojoExecutionException( "No device found for android.device=" + device );
+            throw new MojoExecutionException( "No device found for android.device=" + getDevices().toString() );
         }
     }
 
@@ -800,7 +810,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
             }
             catch ( InterruptedException e )
             {
-                new MojoExecutionException( "Thread#join error for device: " + device );
+                new MojoExecutionException( "Thread#join error for device: " + getDevices().toString() );
             }
         }
     }
@@ -833,26 +843,30 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      */
     private boolean shouldDoWithThisDevice( IDevice idevice ) throws MojoExecutionException, MojoFailureException
     {
-        // use specified device or all emulators or all devices
-        if ( "emulator".equals( device ) && idevice.isEmulator() )
-        {
-            return true;
-        }
 
-        if ( "usb".equals( device ) && ! idevice.isEmulator() )
+        for ( String device : getDevices() )
         {
-            return true;
-        }
+            // use specified device or all emulators or all devices
+            if ( "emulator".equals( device ) && idevice.isEmulator() )
+            {
+                return true;
+            }
 
-        if ( idevice.isEmulator() && ( device.equalsIgnoreCase( idevice.getAvdName() ) || device
-                .equalsIgnoreCase( idevice.getSerialNumber() ) ) )
-        {
-            return true;
-        }
+            if ( "usb".equals( device ) && ! idevice.isEmulator() )
+            {
+                return true;
+            }
 
-        if ( ! idevice.isEmulator() && device.equals( idevice.getSerialNumber() ) )
-        {
-            return true;
+            if ( idevice.isEmulator() && ( device.equalsIgnoreCase( idevice.getAvdName() ) || device
+                    .equalsIgnoreCase( idevice.getSerialNumber() ) ) )
+            {
+                return true;
+            }
+
+            if ( ! idevice.isEmulator() && device.equals( idevice.getSerialNumber() ) )
+            {
+                return true;
+            }
         }
 
         return false;
@@ -1276,6 +1290,17 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         return overlayDirectories;
     }
 
+    private Set<String> getDevices()
+    {
+        Set<String> list = new HashSet<String>();
+
+        list.add( device );
+
+        list.addAll( Arrays.asList( devices ) );
+
+        return list;
+    }
+
     private abstract class DoThread extends Thread
     {
         private MojoFailureException failure;
@@ -1338,5 +1363,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         {
             throw new MojoExecutionException( "Could not copy source folder to target folder", e );
         }
+
     }
+
 }


### PR DESCRIPTION
Hi everybody, 

My first Pull Request for your amazing plugin. I hope my contribution is good enough. Feedback is welcome. 

Instead of the `<device>` parameter, we can now specify a list of devices thanks to the `<devices>` parameter : 

```
<devices>
    <device>serial1</device>
    <device>serial2</device>
</devices>
```
