### PR TITLE
Do not always capture stdout - only when we need it

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -936,6 +936,8 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     {
         CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
         executor.setLogger( this.getLog() );
+        executor.setCaptureStdOut( true );
+        executor.setCaptureStdErr( true );
         List<String> commands = new ArrayList<String>();
         commands.add( "dump" );
         commands.add( "xmltree" );


### PR DESCRIPTION
Hi Manfred,

Ran into out of memory issues with the native plugin and it was due to the fact that the complete std out was captured by default.

This patch only captures std out when it is really needed.

Johan
