### PR TITLE
Fixed the ProGuard config path that contains ' - '

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -370,16 +370,16 @@ public class ProguardMojo extends AbstractAndroidMojo
         commands.add( "-jar" );
         commands.add( parsedProguardJarPath );
 
-        commands.add( "@" + parsedConfig );
+        commands.add( "@\"" + parsedConfig + "\"" );
 
         for ( String config : parsedConfigs )
         {
-            commands.add( "@" + config );
+            commands.add( "@\"" + config + "\"" );
         }
 
         if ( proguardFile != null )
         {
-            commands.add( "@" + proguardFile.getAbsolutePath() );
+            commands.add( "@\"" + proguardFile.getAbsolutePath() + "\"" );
         }
 
         collectInputFiles( commands );


### PR DESCRIPTION
Failed to run ProGuard when the path to the proguard.cfg contains ' - '. e.g. @/Users/mmadev/proguard - project/proguard.cfg. Added quotes to the ProGuard config path.
