### PR TITLE
Fix proguard on windows

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -292,9 +292,9 @@ public class ProguardMojo extends AbstractAndroidMojo
         {
             if ( excludedFilter != null && !excludedFilter.isEmpty() )
             {
-                StringBuilder sb = new StringBuilder( "'\"" );
+                StringBuilder sb = new StringBuilder( "\"'" );
                     sb.append( path );
-                    sb.append( "\"(" );
+                    sb.append( "'(" );
                 for ( Iterator< String > it = excludedFilter.iterator(); it.hasNext(); )
                 {
                     sb.append( '!' ).append( it.next() );
@@ -303,12 +303,12 @@ public class ProguardMojo extends AbstractAndroidMojo
                         sb.append( ',' );
                     }
                 }
-                sb.append( ")'" );
+                sb.append( ")\"" );
                 return sb.toString();
             }
             else
             {
-                return "\'\"" + path + "\"\'";
+                return path;
             }
         }
 


### PR DESCRIPTION
This fixes proguard on windows.

can someone test on linux?

There were 2 problems:

This is not valid:
-libraryjars "'"C:\Program Files\Java\jdk1.7.0_51\jre\lib\rt.jar"'" 
-> Double quote followed by simple quote then double quote again closes the quote therefore Program file is unknown

And this:
 -injars '"C:\Users\Benoit.m2\repository\org\scala-lang\scala-library\2.8.0\scala-library-2.8.0.jar"(!META-INF/maven/**,!META-INF/MANIFEST.MF)' 

-> You first need a double quote and then a simple quote
