### PR TITLE
Attach jar artifact if instructed to (fix for issue 139)

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
@@ -132,6 +132,13 @@ public class ApklibMojo extends AbstractAndroidMojo
             // If there is a classifier specified, attach the artifact using that
             projectHelper.attachArtifact( project, outputFile, classifier );
         }
+
+        if ( attachJar )
+        {
+            final File jarFile = new File( project.getBuild().getDirectory(),
+                    project.getBuild().getFinalName() + ".jar" );
+            projectHelper.attachArtifact( project, "jar", project.getArtifact().getClassifier(), jarFile );
+        }
     }
 
     /**


### PR DESCRIPTION
Simple fix for plugin issue #139 (executing plugin with apklib packagin does not attach resulting jar artifact).

My contact email is leonid-AT-hot-THEDOT-ee as I noticed this is something asked from every contributor.

UPDATE: Fixed a compilation error and squashed two commits into one.
