### PR TITLE
Supports no api level

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AndroidSdk.java
@@ -65,7 +65,7 @@ public class AndroidSdk
     private File platformToolsPath;
     private File toolsPath;
 
-    private IAndroidTarget androidTarget;
+    private final IAndroidTarget androidTarget;
     private SdkManager sdkManager;
     private int sdkMajorVersion;
 
@@ -90,13 +90,11 @@ public class AndroidSdk
         {
             apiLevel = DEFAULT_ANDROID_API_LEVEL;
         }
-        else
+
+        androidTarget = findPlatformByApiLevel( apiLevel );
+        if ( androidTarget == null )
         {
-            androidTarget = findPlatformByApiLevel( apiLevel );
-            if ( androidTarget == null )
-            {
-                throw invalidSdkException( sdkPath, apiLevel );
-            }
+            throw invalidSdkException( sdkPath, apiLevel );
         }
     }
 
@@ -298,7 +296,12 @@ public class AndroidSdk
      */
     public File getAndroidJar() throws MojoExecutionException
     {
-        return new File( androidTarget.getPath( IAndroidTarget.ANDROID_JAR ) );
+        final String androidJarPath = androidTarget.getPath( IAndroidTarget.ANDROID_JAR );
+        if ( androidJarPath == null )
+        {
+            throw new MojoExecutionException( "No AndroidJar found for " + androidTarget );
+        }
+        return new File ( androidJarPath );
     }
   
     /**


### PR DESCRIPTION
Currently if no api level is specified then plugin defaults the Api level but then barfs with a NPE trying to find android.jar. This change takes the default api level and uses that to find android.jar
