### PR TITLE
Fix proguard for AAR deps

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -843,11 +843,12 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
         // Generate the BuildConfig for any apklib dependencies.
         for ( Artifact artifact : getTransitiveDependencyArtifacts() )
         {
-            if ( artifact.getType().equals( APKLIB ) )
+            // Need to generate for AAR too, because some old AARs like ActionBarSherlock do not have BuildConfig (or R)
+            if ( artifact.getType().equals( APKLIB ) || artifact.getType().equals( AAR ) )
             {
-                final File apklibManifeset = new File( getUnpackedLibFolder( artifact ), "AndroidManifest.xml" );
-                final String apklibPackageName = extractPackageNameFromAndroidManifest( apklibManifeset );
-                generateBuildConfigForPackage( apklibPackageName );
+                final File manifest = new File( getUnpackedLibFolder( artifact ), "AndroidManifest.xml" );
+                final String depPackageName = extractPackageNameFromAndroidManifest( manifest );
+                generateBuildConfigForPackage( depPackageName );
             }
         }
     }


### PR DESCRIPTION
Needed to add AAR classes jar to proguard inputs.
Also needed to create BuildConfig for old AARs that don't have them (such as ABS).

Also added a test case for this in the samples.
