### PR TITLE
Add parameter to configure number of threads used in device operations

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -54,6 +54,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
@@ -70,6 +72,7 @@ import static org.apache.commons.lang.StringUtils.isBlank;
  * @author Manfred Moser <manfred@simpligility.com>
  * @author William Ferguson <william.ferguson@xandar.com.au>
  * @author Malachi de AElfweald malachid@gmail.com
+ * @author Roy Clarkson <rclarkson@gopivotal.com>
  */
 public abstract class AbstractAndroidMojo extends AbstractMojo
 {
@@ -272,6 +275,16 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      * @parameter expression="${android.devices}"
      */
     protected String[] devices;
+    
+    /**
+     * <p>Specifies the number of threads to use for deploying and testing on attached devices.
+     * 
+     * <p>This parameter can also be configured from command-line with
+     * parameter <code>-Dandroid.deviceThreads=2</code>.</p>
+     *
+     * @parameter expression="${android.deviceThreads}"
+     */
+    protected int deviceThreads;
 
     /**
      * A selection of configurations to be included in the APK as a comma separated list. This will limit the
@@ -737,6 +750,17 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
             throw new MojoExecutionException( "No online devices attached." );
         }
 
+        int threadCount = getDeviceThreads();
+        if ( getDeviceThreads() == 0 )
+        {
+            getLog().info( "android.devicesThreads parameter not set, using a thread for each attached device" );
+            threadCount = numberOfDevices;
+        }
+        else
+        {
+            getLog().info( "android.devicesThreads parameter set to " + getDeviceThreads() );
+        }
+
         boolean shouldRunOnAllDevices = getDevices().size() == 0;
         if ( shouldRunOnAllDevices )
         {
@@ -748,6 +772,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         }
 
         ArrayList<DoThread> doThreads = new ArrayList<DoThread>();
+        ExecutorService executor = Executors.newFixedThreadPool( threadCount );
         for ( final IDevice idevice : devices )
         {
             if ( shouldRunOnAllDevices )
@@ -764,31 +789,19 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
                     }
                 };
                 doThreads.add( deviceDoThread );
-                deviceDoThread.start();
+                executor.execute( deviceDoThread );
             }
         }
-
-        joinAllThreads( doThreads );
+        executor.shutdown();
+        while ( ! executor.isTerminated() )
+        {
+            // waiting for threads finish
+        }
         throwAnyDoThreadErrors( doThreads );
 
         if ( ! shouldRunOnAllDevices && doThreads.isEmpty() )
         {
             throw new MojoExecutionException( "No device found for android.device=" + getDevices().toString() );
-        }
-    }
-
-    private void joinAllThreads( ArrayList<DoThread> doThreads )
-    {
-        for ( Thread deviceDoThread : doThreads )
-        {
-            try
-            {
-                deviceDoThread.join();
-            }
-            catch ( InterruptedException e )
-            {
-                new MojoExecutionException( "Thread#join error for device: " + getDevices().toString() );
-            }
         }
     }
 
@@ -1310,6 +1323,11 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         list.addAll( Arrays.asList( devices ) );
 
         return list;
+    }
+    
+    private int getDeviceThreads()
+    {
+        return deviceThreads;
     }
 
     private abstract class DoThread extends Thread


### PR DESCRIPTION
Some platforms may not be able to support a large number of concurrent
device operations. Set 'android.deviceThreads' to limit the number
threads available in the thread pool. By default the thread pool size
is based on the number of attached devices.

I consistently experience a `java.io.IOException` when attempting to deploy and test on more than four attached devices. This is any combination of physical devices and emulators. If there are more than four devices reported by the Android Debug Bridge, then the parallel execution of device functions will fail with the following exception. I've tested on three different macs running various versions of Java. Unfortunately, I don't have a windows or linux machine available for testing.

```
    Install of test.apk failed.
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:108)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:116)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:361)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: 20080411413fc082_Contel_TAB-730 :   Install of /Users/rclarkson/Projects/spring-projects/spring-android/test/spring-android-core-test/target/spring-android-core-test.apk failed.
    at com.jayway.maven.plugins.android.AbstractAndroidMojo$1.doWithDevice(AbstractAndroidMojo.java:654)
    at com.jayway.maven.plugins.android.AbstractAndroidMojo$2.runDo(AbstractAndroidMojo.java:763)
    at com.jayway.maven.plugins.android.AbstractAndroidMojo$DoThread.run(AbstractAndroidMojo.java:1324)
Caused by: com.android.ddmlib.InstallException: Broken pipe
    at com.android.ddmlib.Device.installPackage(Device.java:880)
    at com.jayway.maven.plugins.android.AbstractAndroidMojo$1.doWithDevice(AbstractAndroidMojo.java:641)
    ... 2 more
Caused by: java.io.IOException: Broken pipe
    at sun.nio.ch.FileDispatcherImpl.write0(Native Method)
    at sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:47)
    at sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:93)
    at sun.nio.ch.IOUtil.write(IOUtil.java:65)
    at sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:487)
    at com.android.ddmlib.AdbHelper.write(AdbHelper.java:731)
    at com.android.ddmlib.AdbHelper.write(AdbHelper.java:709)
    at com.android.ddmlib.AdbHelper.setDevice(AdbHelper.java:770)
    at com.android.ddmlib.SyncService.openSync(SyncService.java:168)
    at com.android.ddmlib.Device.getSyncService(Device.java:514)
    at com.android.ddmlib.Device.syncPackageToDevice(Device.java:901)
    at com.android.ddmlib.Device.installPackage(Device.java:875)
    ... 3 more
```
