### PR TITLE
Add Connect and Disconnect mojos

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -274,6 +274,24 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     protected String[] devices;
 
     /**
+     * <p>External IP addresses. The connect goal of the android maven plugin  will execute an adb connect on
+     * each IP address. If you have external dervice, you should call this connect goal before any other goal :
+     * mvn clean android:connect install.</p>
+     * <p>The Maven plugin will automatically add all these IP addresses into the the devices parameter.
+     * If you want to disconnect the IP addresses after the build, you can call the disconnect goal :
+     * mvn clean android:connect install android:disconnect</p>
+     *
+     * <pre>
+     * &lt;ips&gt;
+     *     &lt;ip&gt;127.0.0.1:5556&lt;/ip&gt;
+     * &lt;/ips&gt;
+     * </pre>
+     *
+     * @parameter expression="${android.ips}"
+     */
+    protected String[] ips;
+
+    /**
      * A selection of configurations to be included in the APK as a comma separated list. This will limit the
      * configurations for a certain type. For example, specifying <code>hdpi</code> will exclude all resource folders
      * with the <code>mdpi</code> or <code>ldpi</code> modifiers, but won't affect language or orientation modifiers.
@@ -1308,6 +1326,8 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         }
 
         list.addAll( Arrays.asList( devices ) );
+
+        list.addAll( Arrays.asList( ips ) );
 
         return list;
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ConnectMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ConnectMojo.java
@@ -1,0 +1,54 @@
+package com.jayway.maven.plugins.android.standalonemojos;
+
+import com.jayway.maven.plugins.android.AbstractAndroidMojo;
+import com.jayway.maven.plugins.android.CommandExecutor;
+import com.jayway.maven.plugins.android.ExecutionException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Connect external IP addresses to the ADB server.
+ *
+ * @author demey.emmanuel@gmail.com
+ * @goal connect
+ * @requiresProject false
+ */
+public class ConnectMojo extends AbstractAndroidMojo
+{
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException
+    {
+
+        if ( ips.length > 0 )
+        {
+            CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
+
+            for ( String ip : ips )
+            {
+                getLog().debug( "Connecting " + ip );
+
+                String command = getAndroidSdk().getAdbPath();
+                List<String> parameters = new ArrayList<String>();
+                parameters.add( "connect" );
+                parameters.add( ip );
+
+                try
+                {
+                    executor.executeCommand( command, parameters );
+
+                }
+                catch ( ExecutionException e )
+                {
+                    throw new MojoExecutionException( String.format( "Can not connect %s", ip ), e );
+                }
+
+            }
+
+        }
+
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DisconnectMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DisconnectMojo.java
@@ -1,0 +1,55 @@
+package com.jayway.maven.plugins.android.standalonemojos;
+
+import com.jayway.maven.plugins.android.AbstractAndroidMojo;
+import com.jayway.maven.plugins.android.CommandExecutor;
+import com.jayway.maven.plugins.android.ExecutionException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Disconnect external IP addresses from the ADB server.
+ *
+ * @author demey.emmanuel@gmail.com
+ * @goal disconnect
+ * @requiresProject false
+ */
+public class DisconnectMojo extends AbstractAndroidMojo
+{
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException
+    {
+
+        if ( ips.length > 0 )
+        {
+            CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
+
+            for ( String ip : ips )
+            {
+                getLog().debug( "Disconnecting " + ip );
+
+                String command = getAndroidSdk().getAdbPath();
+
+                List<String> parameters = new ArrayList<String>();
+                parameters.add( "disconnect" );
+                parameters.add( ip );
+
+                try
+                {
+                    executor.executeCommand( command, parameters );
+
+                }
+                catch ( ExecutionException e )
+                {
+                    throw new MojoExecutionException( String.format( "Can not disconnect %s", ip ), e );
+                }
+
+            }
+
+        }
+
+    }
+}


### PR DESCRIPTION
With this PR, it is now possible to add external IP in the global configuration : for example 
<ips>
    <ip>127.0.0.1:555</ip>
</ips>

This list of IPs will be added automatically to the list of devices. 
Before running any maven goal, if you have external IPs, we should run mvn android:connect. 

The andoird:disconnect goal will disconnect all the IPs we have configured in the pom.xml. 

Manu
