### PR TITLE
Allowing multi-project builds with internal deps that have never been built to at least start to build

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
@@ -76,7 +76,8 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
             }
             catch ( MojoExecutionException e )
             {
-                throw new MavenExecutionException( "Could not resolve dependencies for project : " + project, e );
+                log.warn( "Could not resolve all dependencies for " + project );
+                continue;
             }
 
             log.debug( "projects deps: : " + artifacts );


### PR DESCRIPTION
Maven-Dependency-Tree doesn't seem to resolve from within the reactor. (I thought it did).
Fix for #309 

This means that while we can fix things so that the build can proceed, we have a small problem with multi-module builds that have never been built that have a dep on an AAR or APK. We won't be able to resolve the deps for these projects, so we won't be able to add the AAR/APK classes to the classpath.

Not sure how to best resolve that. Options:
1) Note that you have to have built your AAR at least once before it can be used as a dep in an APK
2) Making maven-dependency-tree resolve from reactor.
3) Finding alternate for dep resolution that works for both Maven 3 and 3.1 and repo/reactor.
