### PR TITLE
Adding skip parameter to Mojos

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -29,6 +29,7 @@ import com.jayway.maven.plugins.android.common.UnpackedLibHelper;
 import com.jayway.maven.plugins.android.config.ConfigPojo;
 import com.jayway.maven.plugins.android.configuration.Ndk;
 import com.jayway.maven.plugins.android.configuration.Sdk;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.jxpath.JXPathContext;
@@ -487,6 +488,13 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      * @parameter expression="${android.release}" default-value="false"
      */
     protected boolean release;
+    
+    /**
+     * Skips Mojo execution.
+     * 
+     * @parameter default-value="false"
+     */
+    private boolean skip;
 
     private UnpackedLibHelper unpackedLibHelper;
     private ArtifactResolverHelper artifactResolverHelper;
@@ -1449,4 +1457,19 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         }
         return nativeHelper;
     }
+    
+    @Override
+    public final void execute() throws MojoExecutionException, MojoFailureException
+    {
+        if ( ! skip )
+        {
+            doExecute();
+        }
+        else
+        {
+            getLog().info( "skipping execution" );
+        }
+    }
+
+    protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
 }

--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -190,7 +190,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException if it fails.
      * @throws MojoFailureException if it fails.
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         // If the current POM isn't an Android-related POM, then don't do

--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -356,7 +356,7 @@ public class ProguardMojo extends AbstractAndroidMojo
     }
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
@@ -332,7 +332,7 @@ public class NdkBuildMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         try
         {

--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -156,7 +156,7 @@ public class DexMojo extends AbstractAndroidMojo
      * @throws MojoFailureException
      */
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();

--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/EmmaMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/EmmaMojo.java
@@ -79,7 +79,7 @@ public class EmmaMojo extends AbstractAndroidMojo
     private String parsedFilters;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         getLog().debug( "Emma start working. Before parse configuration" );
         parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
@@ -118,7 +118,7 @@ public class AarMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         String out = project.getBuild().getDirectory();
         for ( String src : project.getCompileSourceRoots() )

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -270,7 +270,7 @@ public class ApkMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         // Make an early exit if we're not supposed to generate the APK

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
@@ -104,7 +104,7 @@ public class ApklibMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         String out = project.getBuild().getDirectory();
         for ( String src : project.getCompileSourceRoots() )

--- a/src/main/java/com/jayway/maven/plugins/android/phase11preintegrationtest/InternalPreIntegrationTestMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase11preintegrationtest/InternalPreIntegrationTestMojo.java
@@ -32,7 +32,7 @@ import org.apache.maven.plugin.MojoFailureException;
 public class InternalPreIntegrationTestMojo extends AbstractInstrumentationMojo
 {
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         if ( isEnableIntegrationTest() )
         {

--- a/src/main/java/com/jayway/maven/plugins/android/phase12integrationtest/InternalIntegrationTestMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase12integrationtest/InternalIntegrationTestMojo.java
@@ -32,7 +32,7 @@ import org.apache.maven.plugin.MojoFailureException;
 public class InternalIntegrationTestMojo extends AbstractInstrumentationMojo
 {
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         if ( isEnableIntegrationTest() )
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ConnectMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ConnectMojo.java
@@ -20,7 +20,7 @@ public class ConnectMojo extends AbstractAndroidMojo
 {
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         if ( ips.length > 0 )

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DeployApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DeployApkMojo.java
@@ -73,7 +73,7 @@ public class DeployApkMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DeployDependenciesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DeployDependenciesMojo.java
@@ -39,7 +39,7 @@ public class DeployDependenciesMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         deployDependencies();
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DeployMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DeployMojo.java
@@ -44,7 +44,7 @@ public class DeployMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         deployBuiltApk();
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DevicesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DevicesMojo.java
@@ -27,7 +27,7 @@ public class DevicesMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         doWithDevices( new DeviceCallback()
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DisconnectMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/DisconnectMojo.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class DisconnectMojo extends AbstractAndroidMojo
 {
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         if ( ips.length > 0 )
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/EmulatorStartMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/EmulatorStartMojo.java
@@ -20,7 +20,7 @@ public class EmulatorStartMojo extends AbstractEmulatorMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         startAndroidEmulator();
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/EmulatorStopAllMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/EmulatorStopAllMojo.java
@@ -20,7 +20,7 @@ public class EmulatorStopAllMojo extends AbstractEmulatorMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         stopAndroidEmulators();
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/EmulatorStopMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/EmulatorStopMojo.java
@@ -20,7 +20,7 @@ public class EmulatorStopMojo extends AbstractEmulatorMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         stopAndroidEmulator();
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/InstrumentMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/InstrumentMojo.java
@@ -34,7 +34,7 @@ public class InstrumentMojo extends AbstractInstrumentationMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         instrument();
     }

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/LintMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/LintMojo.java
@@ -360,7 +360,7 @@ public class LintMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      */
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
@@ -296,7 +296,7 @@ public class ManifestUpdateMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         if ( ! AndroidExtension.isAndroidPackaging( project.getPackaging() ) )
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/MonkeyMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/MonkeyMojo.java
@@ -460,7 +460,7 @@ public class MonkeyMojo extends AbstractAndroidMojo
     private Boolean parsedCreateReport;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/MonkeyRunnerMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/MonkeyRunnerMojo.java
@@ -255,7 +255,7 @@ public class MonkeyRunnerMojo extends AbstractAndroidMojo
     private MonkeyRunnerErrorListener errorListener;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PullMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PullMojo.java
@@ -103,7 +103,7 @@ public class PullMojo extends AbstractAndroidMojo
     @PullParameter( required = true )
     private String parsedDestination;
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PushMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PushMojo.java
@@ -101,7 +101,7 @@ public class PushMojo extends AbstractAndroidMojo
     @PullParameter( required = true )
     private String parsedDestination;
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RedeployApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RedeployApkMojo.java
@@ -66,7 +66,7 @@ public class RedeployApkMojo extends AbstractAndroidMojo
     @PullParameter
     private File parsedFilename;
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RedeployMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RedeployMojo.java
@@ -40,7 +40,7 @@ import org.apache.maven.plugin.MojoFailureException;
 public class RedeployMojo extends AbstractAndroidMojo
 {
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         if ( project.getPackaging().equals( APK ) )
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RunMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RunMojo.java
@@ -160,7 +160,7 @@ public class RunMojo extends AbstractAndroidMojo
      * {@inheritDoc}
      */
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         try
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UIAutomatorMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UIAutomatorMojo.java
@@ -333,7 +333,7 @@ public class UIAutomatorMojo extends AbstractAndroidMojo
     private String parsedPropertiesKeyPrefix;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UndeployApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UndeployApkMojo.java
@@ -81,7 +81,7 @@ public class UndeployApkMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
         configHandler.parseConfiguration();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UndeployMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UndeployMojo.java
@@ -44,7 +44,7 @@ public class UndeployMojo extends AbstractAndroidMojo
      * @throws MojoExecutionException
      * @throws MojoFailureException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
         String packageToUndeploy;
         if ( project.getPackaging().equals( AndroidExtension.APK ) ) 

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UnpackMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/UnpackMojo.java
@@ -78,7 +78,7 @@ public class UnpackMojo extends AbstractAndroidMojo
     @ConfigPojo( prefix = "unpack" )
     private Unpack unpack;
 
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ZipalignMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ZipalignMojo.java
@@ -108,7 +108,7 @@ public class ZipalignMojo extends AbstractAndroidMojo
      *
      * @throws MojoExecutionException
      */
-    public void execute() throws MojoExecutionException, MojoFailureException
+    public void doExecute() throws MojoExecutionException, MojoFailureException
     {
 
         // If we're not on a supported packaging with just skip (Issue 87)

--- a/src/test/java/com/jayway/maven/plugins/android/AbstractAndroidMojoTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/AbstractAndroidMojoTest.java
@@ -111,13 +111,13 @@ public class AbstractAndroidMojoTest {
             return new SdkTestSupport().getSdk_with_platform_default();
         }
 
-        public void execute() throws MojoExecutionException, MojoFailureException {
+        public void doExecute() throws MojoExecutionException, MojoFailureException {
 
         }
     }
 
     private class EmptyAndroidMojo extends AbstractAndroidMojo {
-        public void execute() throws MojoExecutionException, MojoFailureException {
+        public void doExecute() throws MojoExecutionException, MojoFailureException {
         }
     }
 }

--- a/src/test/java/com/jayway/maven/plugins/android/AbstractEmulatorMojoTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/AbstractEmulatorMojoTest.java
@@ -117,7 +117,7 @@ public class AbstractEmulatorMojoTest
         }
 
         @Override
-        public void execute() throws MojoExecutionException, MojoFailureException
+        public void doExecute() throws MojoExecutionException, MojoFailureException
         {
         }
 


### PR DESCRIPTION
This PR adds a skip parameter to the android maven plugin, so it is possible to use the packaging=apk and avoid the execution of goals associated to the default lifecycle.

We use this parameter to reduce the build time (maven clean install) in our project http://github.com/e-ucm/ead/ that is a multiplatform application, and the time related to building the apk was anoying most of our developers (those not dealing specifically with android).
