### PR TITLE
Allow the ability to specify an artifact name

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -146,6 +146,13 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     protected MojoExecution execution;
 
     /**
+     * The final name of the artifact.
+     *
+     * @parameter expression="${android.artifactName}" default-value="${project.build.finalName}"
+     */
+    protected String artifactName;
+
+    /**
      * The java sources directory.
      *
      * @parameter default-value="${project.build.sourceDirectory}"
@@ -722,7 +729,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     {
         if ( project.getPackaging().equals( APK ) )
         {
-            File apkFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + "." + APK );
+            File apkFile = new File( project.getBuild().getDirectory(), artifactName + "." + APK );
             deployApk( apkFile );
         }
         else 

--- a/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase05compile/NdkBuildMojo.java
@@ -912,8 +912,7 @@ public class NdkBuildMojo extends AbstractAndroidMojo
             MavenArchiver mavenArchiver = new MavenArchiver();
             mavenArchiver.setArchiver( jarArchiver );
 
-            final File jarFile = new File( new File( project.getBuild().getDirectory() ),
-                    project.getBuild().getFinalName() + ".har" );
+            final File jarFile = new File( new File( project.getBuild().getDirectory() ), artifactName + ".har" );
 
             mavenArchiver.setOutputFile( jarFile );
 

--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -173,8 +173,7 @@ public class DexMojo extends AbstractAndroidMojo
 
         if ( attachJar )
         {
-            File jarFile = new File( project.getBuild().getDirectory() + File.separator
-                    + project.getBuild().getFinalName() + ".jar" );
+            File jarFile = new File( project.getBuild().getDirectory() + File.separator + artifactName + ".jar" );
             projectHelper.attachArtifact( project, "jar", project.getArtifact().getClassifier(), jarFile );
         }
 
@@ -484,8 +483,7 @@ public class DexMojo extends AbstractAndroidMojo
      */
     protected File createApkSourcesFile() throws MojoExecutionException
     {
-        final File apksources = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName()
-                + ".apksources" );
+        final File apksources = new File( project.getBuild().getDirectory(), artifactName + ".apksources" );
         FileUtils.deleteQuietly( apksources );
 
         try

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
@@ -154,8 +154,7 @@ public class AarMojo extends AbstractAndroidMojo
      */
     protected File createAarClassesJar() throws MojoExecutionException
     {
-        final File classesJar = new File( project.getBuild().getDirectory(),
-                project.getBuild().getFinalName() + ".aar.classes.jar" );
+        final File classesJar = new File( project.getBuild().getDirectory(), artifactName + ".aar.classes.jar" );
         try
         {
             JarArchiver jarArchiver = new JarArchiver();
@@ -182,8 +181,7 @@ public class AarMojo extends AbstractAndroidMojo
      */
     protected File createAarLibraryFile( File classesJar ) throws MojoExecutionException
     {
-        final File aarLibrary = new File( project.getBuild().getDirectory(),
-                project.getBuild().getFinalName() + "." + AAR );
+        final File aarLibrary = new File( project.getBuild().getDirectory(), artifactName + "." + AAR );
         FileUtils.deleteQuietly( aarLibrary );
 
         try
@@ -368,7 +366,7 @@ public class AarMojo extends AbstractAndroidMojo
         File[] overlayDirectories = getResourceOverlayDirectories();
 
         File androidJar = getAndroidSdk().getAndroidJar();
-        File outputFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + ".ap_" );
+        File outputFile = new File( project.getBuild().getDirectory(), artifactName + ".ap_" );
 
         List<String> commands = new ArrayList<String>();
         commands.add( "package" );

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -299,7 +299,7 @@ public class ApkMojo extends AbstractAndroidMojo
         }
         
         // Initialize apk build configuration
-        File outputFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + "." + APK );
+        File outputFile = new File( project.getBuild().getDirectory(), artifactName + "." + APK );
         final boolean signWithDebugKeyStore = getAndroidSigner().isSignWithDebugKeyStore();
 
         if ( getAndroidSigner().shouldCreateBothSignedAndUnsignedApk() )
@@ -307,7 +307,7 @@ public class ApkMojo extends AbstractAndroidMojo
             getLog().info( "Creating debug key signed apk file " + outputFile );
             createApkFile( outputFile, true );
             final File unsignedOutputFile = new File( project.getBuild().getDirectory(),
-                    project.getBuild().getFinalName() + "-unsigned." + APK );
+                    artifactName + "-unsigned." + APK );
             getLog().info( "Creating additional unsigned apk file " + unsignedOutputFile );
             createApkFile( unsignedOutputFile, false );
             projectHelper.attachArtifact( project, unsignedOutputFile,
@@ -333,7 +333,7 @@ public class ApkMojo extends AbstractAndroidMojo
     void createApkFile( File outputFile, boolean signWithDebugKeyStore ) throws MojoExecutionException
     {
         File dexFile = new File( project.getBuild().getDirectory(), "classes.dex" );
-        File zipArchive = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + ".ap_" );
+        File zipArchive = new File( project.getBuild().getDirectory(), artifactName + ".ap_" );
         ArrayList<File> sourceFolders = new ArrayList<File>();
         if ( sourceDirectories != null )
         {
@@ -953,7 +953,7 @@ public class ApkMojo extends AbstractAndroidMojo
         File[] overlayDirectories = getResourceOverlayDirectories();
 
         File androidJar = getAndroidSdk().getAndroidJar();
-        File outputFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + ".ap_" );
+        File outputFile = new File( project.getBuild().getDirectory(), artifactName + ".ap_" );
 
         List<String> commands = new ArrayList<String>();
         commands.add( "package" );

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
@@ -145,8 +145,7 @@ public class ApklibMojo extends AbstractAndroidMojo
      */
     protected File createApkLibraryFile() throws MojoExecutionException
     {
-        final File apklibrary = new File( project.getBuild().getDirectory(),
-                project.getBuild().getFinalName() + "." + APKLIB );
+        final File apklibrary = new File( project.getBuild().getDirectory(), artifactName + "." + APKLIB );
         FileUtils.deleteQuietly( apklibrary );
 
         try
@@ -363,7 +362,7 @@ public class ApklibMojo extends AbstractAndroidMojo
         File[] overlayDirectories = getResourceOverlayDirectories();
 
         File androidJar = getAndroidSdk().getAndroidJar();
-        File outputFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + ".ap_" );
+        File outputFile = new File( project.getBuild().getDirectory(), artifactName + ".ap_" );
 
         List<String> commands = new ArrayList<String>();
         commands.add( "package" );

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ZipalignMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ZipalignMojo.java
@@ -222,7 +222,7 @@ public class ZipalignMojo extends AbstractAndroidMojo
     {
         if ( apkFile == null )
         {
-            apkFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + "." + APK );
+            apkFile = new File( project.getBuild().getDirectory(), artifactName + "." + APK );
         }
         return apkFile.getAbsolutePath();
     }
@@ -238,8 +238,7 @@ public class ZipalignMojo extends AbstractAndroidMojo
     {
         if ( alignedApkFile == null )
         {
-            alignedApkFile = new File( project.getBuild().getDirectory(),
-                    project.getBuild().getFinalName() + "-aligned." + APK );
+            alignedApkFile = new File( project.getBuild().getDirectory(), artifactName + "-aligned." + APK );
         }
         return alignedApkFile.getAbsolutePath();
     }


### PR DESCRIPTION
Instead of being forced to project.build.finalName, it would be nice to be able to specify an artifact name in configuration.  This will allow, for example, to be able to use the android:apk goals in other executions with different outputs.
