### PR TITLE
implementing checking for duplicate package name in android artifacts

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -474,13 +474,21 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
      */
     private void checkPackagesForDuplicates() throws MojoExecutionException
     {
+        Set<Artifact> dependencyArtifacts = getTransitiveDependencyArtifacts( AAR, APKLIB );
+
+        if ( dependencyArtifacts.isEmpty() )
+        {
+            //if no AAR or APKLIB dependencies presents than only one package presents
+            return;
+        }
+
         Map<String, Set<Artifact>> packageCompareMap = new HashMap<String, Set<Artifact>>();
 
         HashSet<Artifact> artifactSet = new HashSet<Artifact>();
         artifactSet.add( project.getArtifact() );
         packageCompareMap.put( extractPackageNameFromAndroidManifest( androidManifestFile ), artifactSet );
 
-        for ( Artifact artifact: getTransitiveDependencyArtifacts( AAR, APKLIB ) )
+        for ( Artifact artifact: dependencyArtifacts )
         {
 
             File unpackDir = getUnpackedLibFolder( artifact );


### PR DESCRIPTION
This is very useful because if we ignore case in which several libraries or apk-project have similar package-name in AndroidManifest.xml declared -> R.java of libraries or apk-project may be overridden and lost(and cause compilation error).

In this case I'm writing to log warning message with description of what artifacts has similar package.

example output:
[WARNING] Duplicate packages detected in next artifacts:
    artifacts: "aar_library_1" "application" have similar package: com.example.application
    artifacts: "apklib_library_1" "apklib_library_2" have similar package: com.example.apklib_library
