### PR TITLE
manifest-update couldn't work with non-ASCII.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestUpdateMojo.java
@@ -515,7 +515,7 @@ public class ManifestUpdateMojo extends AbstractAndroidMojo
             manifestFile.getParentFile().mkdirs();
 
             String encoding = doc.getXmlEncoding() != null ? doc.getXmlEncoding() : "UTF-8";
-            writer = new OutputStreamWriter(new FileOutputStream(manifestFile, false), encoding);
+            writer = new OutputStreamWriter( new FileOutputStream( manifestFile, false ), encoding );
             if ( doc.getXmlEncoding() != null && doc.getXmlVersion() != null )
             {
                 String xmldecl = String


### PR DESCRIPTION
when AndroidManifest.xml contains not-ASCII chars, manfiest-update could not work well. when packaging, it may be result error: Error parsing XML: not well-formed (invalid token). Try to fix it with proper encoding.
