### PR TITLE
adding adb connection timeout

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -17,6 +17,7 @@
 package com.jayway.maven.plugins.android;
 
 import com.android.ddmlib.AndroidDebugBridge;
+import com.android.ddmlib.DdmPreferences;
 import com.android.ddmlib.IDevice;
 import com.android.ddmlib.InstallException;
 import com.jayway.maven.plugins.android.common.AndroidExtension;
@@ -488,6 +489,12 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      */
     protected boolean release;
 
+    /**
+     * The timeout value for an adb connection in milliseconds.
+     * @parameter expression="${android.adb.connection.timeout}" default-value="5000"
+     */
+    protected int adbConnectionTimeout;
+
     private UnpackedLibHelper unpackedLibHelper;
     private ArtifactResolverHelper artifactResolverHelper;
     private NativeHelper nativeHelper;
@@ -574,6 +581,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         {
             if ( ! adbInitialized )
             {
+                DdmPreferences.setTimeOut( adbConnectionTimeout );
                 AndroidDebugBridge.init( false );
                 adbInitialized = true;
             }

--- a/src/test/java/com/jayway/maven/plugins/android/AbstractAndroidMojoTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/AbstractAndroidMojoTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.android.ddmlib.DdmPreferences;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -102,6 +103,15 @@ public class AbstractAndroidMojoTest {
         final URL    resource     = this.getClass().getResource("apidemos-platformtests-0.1.0-SNAPSHOT.apk");
         final String foundPackage = androidMojo.extractPackageNameFromApk(new File(new URI(resource.toString())));
         Assert.assertEquals("com.example.android.apis.tests", foundPackage);
+    }
+
+    @Test
+    public void usesAdbConnectionTimeout() throws MojoExecutionException {
+        final int expectedTimeout = 1000;
+        androidMojo.adbConnectionTimeout = expectedTimeout;
+        androidMojo.initAndroidDebugBridge();
+
+        Assert.assertEquals(DdmPreferences.getTimeOut(), expectedTimeout);
     }
 
     private class DefaultTestAndroidMojo extends AbstractAndroidMojo {


### PR DESCRIPTION
This code change allows the user to configure a custom value for the adb connection timeout. This can be quite useful when adb tries to connect to remote devices.
