### PR TITLE
Added #aidlSourceDirectory property

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -177,6 +177,14 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
      * default-value="${project.build.directory}/generated-sources/aidl"
      */
     protected File genDirectoryAidl;
+    
+    /**
+     * The directory containing the aidl files.
+     * 
+     * @parameter property="android.aidlSourceDirectory"
+     * default-value="${project.build.sourceDirectory}"
+     */
+    protected File aidlSourceDirectory;
 
     /**
      * <p>Parameter designed to generate custom BuildConfig constants
@@ -215,7 +223,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
             // Copy project assets to combinedAssets so that aapt has a single assets folder to load.
             copyFolder( assetsDirectory, combinedAssets );
 
-            final String[] relativeAidlFileNames1 = findRelativeAidlFileNames( sourceDirectory );
+            final String[] relativeAidlFileNames1 = findRelativeAidlFileNames( aidlSourceDirectory );
             final String[] relativeAidlFileNames2 = findRelativeAidlFileNames( extractedDependenciesJavaSources );
             final Map<String, String[]> relativeApklibAidlFileNames = new HashMap<String, String[]>();
 
@@ -237,7 +245,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
             // This is so project A, which depends on project B, can
             // use AIDL info from project B in its own AIDL
             Map<File, String[]> files = new HashMap<File, String[]>();
-            files.put( sourceDirectory, relativeAidlFileNames1 );
+            files.put( aidlSourceDirectory, relativeAidlFileNames1 );
             files.put( extractedDependenciesJavaSources, relativeAidlFileNames2 );
             for ( Artifact artifact : getTransitiveDependencyArtifacts( APKLIB ) )
             {


### PR DESCRIPTION
The directory for the .aidl files now can be defined via this property.
If the property is not present, it fallbacks to #sourceDirectory. This
commit implements [issue 173](https://code.google.com/p/maven-android-plugin/issues/detail?id=173).
