### PR TITLE
improving android-run in multimodule project

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RunMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/RunMojo.java
@@ -43,6 +43,8 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 
+import static com.jayway.maven.plugins.android.common.AndroidExtension.APK;
+
 /**
  * Runs the first Activity shown in the top-level launcher as determined by its Intent filters.
  * <p>
@@ -162,20 +164,28 @@ public class RunMojo extends AbstractAndroidMojo
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
-        try
+        if ( project.getPackaging().equals( APK ) )
         {
-            LauncherInfo launcherInfo;
+            try
+            {
+                LauncherInfo launcherInfo;
 
-            launcherInfo = getLauncherActivity();
+                launcherInfo = getLauncherActivity();
 
-            ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
-            configHandler.parseConfiguration();
+                ConfigHandler configHandler = new ConfigHandler( this, this.session, this.execution );
+                configHandler.parseConfiguration();
 
-            launch( launcherInfo );
+                launch( launcherInfo );
+            }
+            catch ( Exception ex )
+            {
+                getLog().info( "Unable to run launcher Activity" );
+                getLog().debug( ex );
+            }
         }
-        catch ( Exception ex )
+        else
         {
-            throw new MojoFailureException( "Unable to run launcher Activity", ex );
+            getLog().info( "Project packaging is not apk, skipping run action." );
         }
     }
 
@@ -187,12 +197,11 @@ public class RunMojo extends AbstractAndroidMojo
      * Gets the first "Launcher" Activity by running an XPath query on <code>AndroidManifest.xml</code>.
      *
      * @return A {@link LauncherInfo}
-     * @throws MojoExecutionException
+     * @throws MojoFailureException
      * @throws ParserConfigurationException
      * @throws IOException
      * @throws SAXException
      * @throws XPathExpressionException
-     * @throws ActivityNotFoundException
      */
     private LauncherInfo getLauncherActivity()
             throws ParserConfigurationException, SAXException, IOException, XPathExpressionException,


### PR DESCRIPTION
making "android:run" behavior in multimodule project similar to "android:deploy" behavior

I think these two commands always use together and it would be very useful if we could use them together in multimodule project(i.e. "mvn clean install android:deploy android:run" from parent module)

Pros: 
- we could use "android:run" from parent module, not necessary to move to folder of a module with apk packaging

Cons:
- if we have several application that can be run in multimodule project they all will run on a device
  (but this case is very rare. And also for user with this case there will be no damage: neither before this feature nor after he will not use "android:run" from parent module. So we even could ignore this lack )

As a result: I think that pros are much bigger than cons for this feature
