### PR TITLE
Passing in reactor projects so that we can resolve reactor dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-dependency-tree</artifactId>
-                <version>2.1</version>
+                <version>2.2-SNAPSHOT</version>
             </dependency>
 
             <!-- test deps -->

--- a/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
@@ -12,8 +12,8 @@ package com.jayway.maven.plugins.android.phase_prebuild;
 
 import com.jayway.maven.plugins.android.common.AndroidExtension;
 import com.jayway.maven.plugins.android.common.ArtifactResolverHelper;
-import com.jayway.maven.plugins.android.common.UnpackedLibHelper;
 import com.jayway.maven.plugins.android.common.DependencyResolver;
+import com.jayway.maven.plugins.android.common.UnpackedLibHelper;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.artifact.Artifact;
@@ -75,11 +75,11 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
             final Set<Artifact> artifacts;
             try
             {
-                artifacts = dependencyResolver.getProjectDependenciesFor( project );
+                artifacts = dependencyResolver.getProjectDependenciesFor( project, session );
             }
             catch ( MojoExecutionException e )
             {
-                log.warn( "Could not resolve all dependencies for " + project );
+                log.warn( "Could not resolve all dependencies for " + project, e );
                 continue;
             }
 


### PR DESCRIPTION
I believe this finally solves the inability to resolve deps that only exist within the reactor.
NB At the moment it relies on a maven-dependency-tree-2.2-SNAPSHOT which you can build from https://github.com/william-ferguson-au/maven-shared/tree/resolving-reactor-deps

Once I have at least two confirmations that everything is good, I will submit the changes to maven-dep-tree.

I have tested against my projects and against the android-maven-plugin-samples/library-projects. library-projects works fine except there is a  proguard issue with action-bar-sherlock which looks like another issue entirely. Hopefully someone who is more awake than me will work out what is wrong.

In order to test you will need to:
- Build maven-dependency-tree-2.2-SNAPSHOT
- Build/merge this branch and build android-maven-plugin
- Delete from your repository any projects that wil be used in your test (before each run).
- Run your tests.
