### PR TITLE
Fixed the construction of R.java files for the dependencies of an APK.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -331,7 +331,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     protected boolean aaptVerbose;
 
     /**
-     * Automatically create a ProGuard configuration file that will guard Activity classes and the like that are 
+     * Automatically create a ProGuard configuration file that will guard Activity classes and the like that are
      * defined in the AndroidManifest.xml. This files is then automatically used in the proguard mojo execution, 
      * if enabled.
      *
@@ -1021,7 +1021,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
         final DocumentContainer documentContainer = new DocumentContainer( xmlURL );
         final Object packageName = JXPathContext.newContext( documentContainer )
                 .getValue( "manifest/@package", String.class );
-        getLog().debug( "Extracting package " + packageName + " from Manifest : "  + androidManifestFile );
+        getLog().debug( "Extracting packageName " + packageName + " from Manifest : "  + androidManifestFile );
         return ( String ) packageName;
     }
 

--- a/src/main/java/com/jayway/maven/plugins/android/common/DependencyCollector.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/DependencyCollector.java
@@ -1,0 +1,89 @@
+package com.jayway.maven.plugins.android.common;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.codehaus.plexus.logging.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Filters a graph of Artifacts and transforms it into a Set.
+ */
+final class DependencyCollector
+{
+    private final Logger log;
+    private final Set<Artifact> dependencies = new HashSet<Artifact>();
+    private final Artifact target;
+
+    /**
+     * @param logger    Logger on which to output and messages.
+     * @param target    Artifact from which we will start collecting.
+     */
+    DependencyCollector( Logger logger, Artifact target )
+    {
+        this.log = logger;
+        this.target = target;
+    }
+
+    /**
+     * Visits all nodes from the given node and collects dependencies.
+     *
+     * @param node          DependencyNode from which to search.
+     * @param collecting    Whether we are currently collecting artifacts.
+     */
+    public void visit( DependencyNode node, boolean collecting )
+    {
+        if ( collecting )
+        {
+            dependencies.add( node.getArtifact() );
+        }
+
+        if ( matchesTarget( node.getArtifact() ) )
+        {
+            collecting = true;
+            log.debug( "Found target. Collecting dependencies after " + node.getArtifact() );
+        }
+
+        for ( final DependencyNode child : node.getChildren() )
+        {
+            visit( child, collecting );
+        }
+    }
+
+    public Set<Artifact> getDependencies()
+    {
+        return Collections.unmodifiableSet( dependencies );
+    }
+
+    private boolean matchesTarget( Artifact found )
+    {
+        return found.getGroupId().equals( target.getGroupId() )
+                && found.getArtifactId().equals( target.getArtifactId() )
+                && found.getVersion().equals( target.getVersion() )
+                && found.getType().equals( target.getType() )
+                && classifierMatch( found.getClassifier(), target.getClassifier() )
+                ;
+    }
+
+    private boolean classifierMatch( String classifierA, String classifierB )
+    {
+        final boolean hasClassifierA = !isNullOrEmpty( classifierA );
+        final boolean hasClassifierB = !isNullOrEmpty( classifierB );
+        if ( !hasClassifierA && !hasClassifierB )
+        {
+            return true;
+        }
+        else if ( hasClassifierA && hasClassifierB )
+        {
+            return classifierA.equals( classifierB );
+        }
+        return false;
+    }
+
+    private boolean isNullOrEmpty( String string )
+    {
+        return ( string == null ) || string.isEmpty();
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -684,16 +684,19 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
     private void generateCorrectRJavaForApklibDependencies( ResourceClassGenerator resourceGenerator )
             throws MojoExecutionException
     {
+        getLog().debug( "" );
+        getLog().debug( "#generateCorrectRJavaFoApklibDeps" );
         // Generate R.java for apklibs
         // Compatibility with Apklib which isn't present in AndroidBuilder
         generateApkLibRs();
 
-        // Generate error corrected R.java for APKLIB dependencies, but only if this is an APK build.
+        // Generate corrected R.java for APKLIB dependencies, but only if this is an APK build.
         final Set<Artifact> apklibDependencies = getTransitiveDependencyArtifacts( APKLIB );
         if ( !apklibDependencies.isEmpty() && APK.equals( project.getArtifact().getType() ) )
         {
             // Generate R.java for each APKLIB based on R.txt
-            getLog().debug( "Generating R file for APKLIB dependencies" );
+            getLog().debug( "" );
+            getLog().debug( "Rewriting R files for APKLIB dependencies : " + apklibDependencies );
             resourceGenerator.generateLibraryRs( apklibDependencies, "apklib" );
         }
     }
@@ -706,7 +709,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
     private void generateCorrectRJavaForAarDependencies( ResourceClassGenerator resourceGenerator )
             throws MojoExecutionException
     {
-        // Generate error corrected R.java for AAR dependencies.
+        // Generate corrected R.java for AAR dependencies.
         final Set<Artifact> aarLibraries = getTransitiveDependencyArtifacts( AAR );
         if ( !aarLibraries.isEmpty() )
         {
@@ -779,7 +782,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
         }
 
         final Set<Artifact> apklibDeps = getDependencyResolver().getLibraryDependenciesFor( project, apklibArtifact );
-        getLog().debug( "apklib dependencies = " + apklibDeps );
+        getLog().debug( "apklib=" + apklibArtifact + "  dependencies=" + apklibDeps );
         for ( Artifact dependency : apklibDeps )
         {
             // Add in the resources that are dependencies of the apklib.


### PR DESCRIPTION
This fixes issue-463.
It also fixes the issue I was having with Proguard failing for libraryprojects-aar-actionbarsherlock-example.

The dependencies passed into appt for R.,java generation were being incorrectly gathered.

NB plugin-samples builds from end to end.
