### PR TITLE
Check missing build-tools

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AndroidSdk.java
@@ -249,10 +249,22 @@ public class AndroidSdk
     {
         if ( androidTarget != null )
         {
-            return androidTarget.getBuildToolInfo().getPath( pathId );
+            BuildToolInfo buildToolInfo = androidTarget.getBuildToolInfo();
+            if ( buildToolInfo != null ) 
+            {
+                return androidTarget.getBuildToolInfo().getPath( pathId );
+            }
         }
-        // if no valid target is defined used the latest
-        return sdkManager.getLatestBuildTool().getPath( pathId );
+        // if no valid target is defined, or it has no build tools installed, try to use the latest
+        BuildToolInfo latestBuildToolInfo = sdkManager.getLatestBuildTool();
+        if ( latestBuildToolInfo == null )
+        {
+            throw new InvalidSdkException( "Invalid SDK: Build-tools not found. Check the content of '" 
+                + sdkPath.getAbsolutePath() + File.separator + "build-tools', or run '" 
+                + sdkPath.getAbsolutePath() + File.separator + "tools" + File.separator 
+                + "android sdk' to install them" );
+        }
+        return latestBuildToolInfo.getPath( pathId );
     }
 
     private String getPathForPlatformTool( String tool )


### PR DESCRIPTION
The android SDK manager, under same circumstances (mainly after an update), can leave you with no build tools. The "build-tools" directory would be empty, and getBuildTools() will return null. This results in a NPE, which is difficult to diagnose (see [Issue 397](https://code.google.com/p/maven-android-plugin/issues/detail?id=397) and [Issue 432](https://code.google.com/p/maven-android-plugin/issues/detail?id=432) on google code).
This pull request checks for this case and produce a more meaningful InvalidSdkException.
