### PR TITLE
Fix for issue #389

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -171,6 +171,13 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     protected File resourceDirectory;
 
     /**
+     * Override default generated folder containing R.java
+     *
+     * @parameter property="android.genDirectory" default-value="${project.build.directory}/generated-sources/r"
+     */
+    protected File genDirectory;
+
+    /**
      * <p>Root folder containing native libraries to include in the application package.</p>
      *
      * @parameter property="android.nativeLibrariesDirectory" default-value="${project.basedir}/libs"

--- a/src/main/java/com/jayway/maven/plugins/android/common/AaptCommandBuilder.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/AaptCommandBuilder.java
@@ -93,7 +93,7 @@ public class AaptCommandBuilder
         }
 
         /**
-         * Make package directories under location specified by {@link #setWhereToOutputResourceConstants}.
+         * Make package directories under location specified by {@link #setResourceConstantsFolder}.
          *
          * @return current instance of {@link AaptCommandBuilder}
          */
@@ -104,12 +104,12 @@ public class AaptCommandBuilder
         }
 
         /**
-         * Specify where to output R java resource constant definitions.
+         * Specify where the R java resource constant definitions should be generated or found.
          *
-         * @param path path where to output R.java
+         * @param path path to resource constants folder.
          * @return current instance of {@link AaptCommandBuilder}
          */
-        public AaptPackageCommandBuilder setWhereToOutputResourceConstants( File path )
+        public AaptPackageCommandBuilder setResourceConstantsFolder( File path )
         {
             commands.add( "-J" );
             commands.add( path.getAbsolutePath() );

--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -189,13 +189,6 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
     private boolean failOnDuplicatePackages;
 
     /**
-     * Override default generated folder containing R.java
-     *
-     * @parameter property="android.genDirectory" default-value="${project.build.directory}/generated-sources/r"
-     */
-    protected File genDirectory;
-
-    /**
      * Override default generated folder containing aidl classes
      *
      * @parameter property="android.genDirectoryAidl"
@@ -708,7 +701,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
         final AaptPackageCommandBuilder commandBuilder = AaptCommandBuilder
                 .packageResources( getLog() )
                 .makePackageDirectories()
-                .setWhereToOutputResourceConstants( genDirectory )
+                .setResourceConstantsFolder( genDirectory )
                 .forceOverwriteExistingFiles()
                 .disablePngCrunching()
                 .generateRIntoPackage( customPackage )
@@ -875,7 +868,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 .packageResources( getLog() )
                 .makeResourcesNonConstant()
                 .makePackageDirectories()
-                .setWhereToOutputResourceConstants( genDirectory )
+                .setResourceConstantsFolder( genDirectory )
                 .generateRIntoPackage( extractPackageNameFromAndroidManifest( apklibManifest ) )
                 .setPathToAndroidManifest( apklibManifest )
                 .addResourceDirectoryIfExists( apklibResDir )

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
@@ -371,7 +371,6 @@ public class AarMojo extends AbstractAndroidMojo
         executor.setLogger( this.getLog() );
 
         File outputFile = new File( project.getBuild().getDirectory(), project.getBuild().getFinalName() + ".ap_" );
-        final File rDir = new File( new File( project.getBuild().getDirectory(), "generated-sources" ), "r" );
 
         final AaptCommandBuilder commandBuilder = AaptCommandBuilder
                 .packageResources( getLog() )
@@ -386,7 +385,7 @@ public class AarMojo extends AbstractAndroidMojo
                 .addExistingPackageToBaseIncludeSet( getAndroidSdk().getAndroidJar() )
                 .setOutputApkFile( outputFile )
                 .addConfigurations( configurations )
-                .setWhereToOutputResourceConstants( rDir )
+                .setResourceConstantsFolder( genDirectory )
                 .makeResourcesNonConstant()
                 .generateRTextFile( new File( project.getBuild().getDirectory() ) )
                 .setVerbose( aaptVerbose );


### PR DESCRIPTION
Allowing AAR to be built using the <genDirectory> config option.
Fix for #389

Q: why do we include the R folder when using aapt to package AAR but not APKLIB or APK?
It seems strange but I am not sure that it is an error.
