### PR TITLE
Fix dependency with library poject that has jar files in libs.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/UnpackedLibHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/UnpackedLibHelper.java
@@ -110,6 +110,12 @@ public final class UnpackedLibHelper
         }
     }
 
+    public File getArtifactToFile( Artifact artifact ) throws MojoExecutionException
+    {
+        final File artifactFile = artifactResolverHelper.resolveArtifactToFile( artifact );
+        return artifactFile;
+    }
+
     public File getUnpackedLibsFolder()
     {
         return unpackedLibsDirectory;

--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -253,8 +254,26 @@ public class DexMojo extends AbstractAndroidMojo
                 }
                 else if ( artifact.getType().equals( APKLIB ) )
                 {
-                    // No classes in an APKLIB to dex.
-                    // Any potential classes will have already bee compiled to target/classes
+                    // jar files under 'libs' in an APKLIB to dex.
+                    final File unpackLibFolder = getUnpackedLibHelper().getUnpackedLibFolder( artifact );
+                    getLog().debug( "Unpacked Lib folder: " + unpackLibFolder );
+                    final File unpackLibLibsFolder = new File( unpackLibFolder, "libs" );
+                    File[] libJarFiles = unpackLibLibsFolder.listFiles( new FilenameFilter()
+                    {
+                        public boolean accept( final File dir, final String name )
+                        {
+                            return name.endsWith( ".jar" );
+                        }
+                    } );
+
+                    if ( libJarFiles != null )
+                    {
+                        for ( File jarFile : libJarFiles )
+                        {
+                            getLog().debug( "Adding dex inputs:" + jarFile );
+                            inputs.add( jarFile.getAbsoluteFile() );
+                        }
+                    }
                     continue;
                 }
                 else if ( artifact.getType().equals( AAR ) )

--- a/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
@@ -21,6 +21,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
@@ -31,8 +32,14 @@ import org.codehaus.plexus.logging.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
 
 /**
  * Adds classes from AAR and APK dependencies to the project compile classpath.
@@ -106,6 +113,8 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
                     // Create a placeholder classes.jar and add it to the compile classpath.
                     // It will replaced with the real classes.jar by GenerateSourcesMojo.
                     addClassesToClasspath( helper, project, artifact );
+                    // Add jar files in 'libs' into classpath.
+                    addLibsJarsToClassPath( helper, project, artifact );
                 }
                 else if ( type.equals( AndroidExtension.APK ) )
                 {
@@ -114,10 +123,68 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
                     // The placeholder will be replaced with the real APK jar later.
                     addClassesToClasspath( helper, project, artifact );
                 }
+                else if ( type.equals( AndroidExtension.APKLIB ) )
+                {
+                    // Add jar files in 'libs' into classpath.
+                    addLibsJarsToClassPath( helper, project, artifact );
+                }
             }
         }
         log.debug( "" );
         log.debug( "ClasspathModifierLifecycleParticipant#afterProjectsRead - finish" );
+    }
+
+    /**
+     * Add jar files in libs into the project classpath.
+     */
+    private void addLibsJarsToClassPath( UnpackedLibHelper helper, MavenProject project, Artifact artifact )
+        throws MavenExecutionException
+    {
+         try
+         {
+             final File unpackLibFolder = helper.getUnpackedLibFolder( artifact );
+             final File artifactFile = helper.getArtifactToFile( artifact );
+             ZipFile zipFile = new ZipFile( artifactFile );
+             Enumeration enumeration = zipFile.entries();
+             while ( enumeration.hasMoreElements() )
+             {
+                 ZipEntry entry = ( ZipEntry )  enumeration.nextElement();
+                 String entryName = entry.getName();
+
+                 // Only jar files under 'libs' directory to be processed.
+                 if ( Pattern.matches( "^libs/.+\\.jar$", entryName ) )
+                 {
+                     final File libsJarFile = new File( unpackLibFolder, entryName );
+                     log.debug( "Adding jar to classpath: " + libsJarFile );
+
+                     // In order to satisfy the LifecycleDependencyResolver on execution up to a phase that
+                     // has a Mojo requiring dependency resolution I need to create a dummy classesJar here.
+                     if ( !libsJarFile.getParentFile().exists() )
+                     {
+                         libsJarFile.getParentFile().mkdirs();
+                     }
+                     libsJarFile.createNewFile();
+
+                     // Add the jar to the classpath.
+                     final Dependency dependency =
+                            createSystemScopeDependency( artifact, libsJarFile, libsJarFile.getName() );
+
+                      project.getModel().addDependency( dependency );
+                 }
+             }
+         }
+         catch ( MojoExecutionException e )
+         {
+             log.debug( "Error extract jars" );
+         }
+         catch ( ZipException e )
+         {
+             log.debug( "Error" );
+         }
+         catch ( IOException e )
+         {
+             log.debug( "Error" );
+         }
     }
 
     /**
@@ -145,15 +212,20 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
         }
 
         // Add the classes to the classpath
-        final Dependency dependency = createSystemScopeDependency( artifact, classesJar );
+        final Dependency dependency = createSystemScopeDependency( artifact, classesJar, null );
         project.getModel().addDependency( dependency );
     }
 
-    private Dependency createSystemScopeDependency( Artifact artifact, File location )
+    private Dependency createSystemScopeDependency( Artifact artifact, File location, String suffix )
     {
+        String artifactId = artifact.getArtifactId();
+        if ( suffix != null )
+        {
+            artifactId = "_" + suffix;
+        }
         final Dependency dependency = new Dependency();
         dependency.setGroupId( artifact.getGroupId() );
-        dependency.setArtifactId( artifact.getArtifactId() );
+        dependency.setArtifactId( artifactId );
         dependency.setVersion( artifact.getVersion() );
         dependency.setScope( Artifact.SCOPE_SYSTEM );
         dependency.setSystemPath( location.getAbsolutePath() );


### PR DESCRIPTION
For Android Library Project that [only] provides jar files in 'libs' directory,
the plugin should:
1, Add the jars into classpath of projects.
2, Add the jars into the dex file list.
