### PR TITLE
Don't compress mp3 asset files

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -422,8 +422,17 @@ public class ApkMojo extends AbstractAndroidMojo
                     continue;
                 }
             }
-
-            zos.putNextEntry( new ZipEntry( zn ) );
+            final ZipEntry ne;
+            if ( ze.getMethod() == ZipEntry.STORED )
+            {
+                ne = new ZipEntry( ze );
+            }
+            else
+            {
+                ne = new ZipEntry( zn );
+            }
+            
+            zos.putNextEntry( ne );
 
             InputStream is = zin.getInputStream( ze );
 


### PR DESCRIPTION
By default Android tooling does not compress certain assets and just puts them in as STORED. Making sure the Maven plugin respects such decision and does not compress them when repackaging the archive. Needed for MediaPlayer to play mp3 from asset folder, as they are required to be uncompressed.

To reproduce the problem one can do:

``` bash
$ hg clone http://source.apidesign.org/hg/html~demo/
$ cd html~demo/
$ hg up -C a57b2414b855
$ mvn install
$ cd minesweeper
```

Now build the APK file and check its content:

``` bash
$ mvn clean install -Pdlvkbrwsr
$ unzip -v target/minesweeper-2.0-SNAPSHOT.apk  | grep mp3
   78720  Defl:N    77605   1% 2014-07-21 08:44 8f3e7251  assets/pages/applause.mp3
    4224  Defl:N     3467  18% 2014-07-21 08:44 b6e7fec7  assets/pages/move.mp3
   55680  Defl:N    54846   2% 2014-07-21 08:44 69193e4d  assets/pages/oops.mp3
```

The mp3 are compressed, which is not good, as then MediaPlayer refuses to play them. They should be stored only. The desired result can be obtained after using my patched version:

``` bash
$ mvn clean install -Pdlvkbrwsr
$ unzip -v target/minesweeper-2.0-SNAPSHOT.apk  | grep mp3
   78720  Stored    78720   0% 2014-07-21 08:33 8f3e7251  assets/pages/applause.mp3
    4224  Stored     4224   0% 2014-07-21 08:33 b6e7fec7  assets/pages/move.mp3
   55680  Stored    55680   0% 2014-07-21 08:33 69193e4d  assets/pages/oops.mp3
```

It would be nice, if my change could get into official release in time, so I can demo my project & maven-android-plugin at JavaOne 2014 in San Francisco.
