### PR TITLE
removed duplicated undeploy

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -670,11 +670,6 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
                 {
                     getLog().debug( "Detected apk dependency " + artifact + ". Will resolve and deploy to device..." );
                     final File targetApkFile = resolveArtifactToFile( artifact );
-                    if ( undeployBeforeDeploy )
-                    {
-                        getLog().debug( "Attempting undeploy of " + targetApkFile + " from device..." );
-                        undeployApk( targetApkFile );
-                    }
                     getLog().debug( "Deploying " + targetApkFile + " to device..." );
                     deployApk( targetApkFile );
                 }


### PR DESCRIPTION
the deployApk method already undeploys the specified apk if the `undeployBeforeDeploy` flag is set.

fyi: if someone has the  `undeployBeforeDeploy` flag set to true and runs the redeploy command this will as well undepoy the apk twice. 

in general this is not really a problem, it just looks weird in the logs. 
