### PR TITLE
Display warning when consuming jars from the libs folder of apklib & aar

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -461,6 +461,18 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     private NativeHelper nativeHelper;
 
     /**
+     * <p>Include jars stored in the libs folder of an apklib as dependencies.</p>
+     */
+    @Parameter( property = "android.includeLibsJarsForApklib", defaultValue = "false" )
+    protected boolean includeLibsJarsForApklib;
+
+    /**
+     * <p>Include jars stored in the libs folder of an aar as dependencies.</p>
+     */
+    @Parameter( property = "android.includeLibsJarsForAar", defaultValue = "false" )
+    protected boolean includeLibsJarsForAar;
+
+    /**
      *
      */
     private static final Object ADB_LOCK = new Object();


### PR DESCRIPTION
Initial conversation here: https://github.com/jayway/maven-android-plugin/commit/249ad1e1eac052c3f1db6bd4c9270c9fb25c0cec#diff-2

Currently this only deactivate apklib libs\jars and consume the aar libs.

I still need to enable the pom flags in some way.
- DO NOT MERGE yet
