### PR TITLE
Changed Dex Mojo so that it includes jars from the AAR libs folder.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/ArtifactResolverHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/ArtifactResolverHelper.java
@@ -35,7 +35,7 @@ public final class ArtifactResolverHelper
      * Which dependency scopes should not be included when unpacking dependencies into the apk.
      */
     protected static final List<String> EXCLUDED_DEPENDENCY_SCOPES = Arrays.asList(
-            Artifact.SCOPE_PROVIDED, Artifact.SCOPE_SYSTEM, Artifact.SCOPE_IMPORT
+            Artifact.SCOPE_PROVIDED, Artifact.SCOPE_IMPORT
     );
 
     private final ArtifactResolver artifactResolver;

--- a/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/NativeHelper.java
@@ -231,7 +231,9 @@ public class NativeHelper
         {
             if ( ! Artifact.SCOPE_PROVIDED.equals( dependency.getScope() ) && ! dependency.isOptional() )
             {
-                transitiveArtifacts.addAll( processTransitiveDependencies( dependency, sharedLibraries ) );
+                final Set<Artifact> transArtifactsFor = processTransitiveDependencies( dependency, sharedLibraries );
+                log.debug( "Found transitive dependencies for : " + dependency + " transDeps : " + transArtifactsFor );
+                transitiveArtifacts.addAll( transArtifactsFor );
             }
         }
 
@@ -242,8 +244,6 @@ public class NativeHelper
     private Set<Artifact> processTransitiveDependencies( Dependency dependency, boolean sharedLibraries )
             throws MojoExecutionException
     {
-        log.debug( "Processing transitive dependencies for : " + dependency );
-
         try
         {
             final Set<Artifact> artifacts = new LinkedHashSet<Artifact>();
@@ -280,7 +280,6 @@ public class NativeHelper
             for ( final DependencyNode dep : dependencies )
             {
                 final boolean isNativeLibrary = isNativeLibrary( sharedLibraries, dep.getArtifact().getType() );
-                log.debug( "Processing library : " + dep.getArtifact() + " isNative=" + isNativeLibrary );
                 if ( isNativeLibrary )
                 {
                     artifacts.add( dep.getArtifact() );

--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -37,7 +37,6 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -243,38 +242,16 @@ public class DexMojo extends AbstractAndroidMojo
                         || artifact.getType().equals( Const.ArtifactType.NATIVE_IMPLEMENTATION_ARCHIVE ) )
                 {
                     // Ignore native dependencies - no need for dexer to see those
-                    continue;
                 }
                 else if ( artifact.getType().equals( APKLIB ) )
                 {
-                    // jar files under 'libs' in an APKLIB to dex.
-                    final File unpackLibFolder = getUnpackedLibHelper().getUnpackedLibFolder( artifact );
-                    getLog().debug( "Unpacked Lib folder: " + unpackLibFolder );
-                    final File unpackLibLibsFolder = new File( unpackLibFolder, "libs" );
-                    File[] libJarFiles = unpackLibLibsFolder.listFiles( new FilenameFilter()
-                    {
-                        public boolean accept( final File dir, final String name )
-                        {
-                            return name.endsWith( ".jar" );
-                        }
-                    } );
-
-                    if ( libJarFiles != null )
-                    {
-                        for ( File jarFile : libJarFiles )
-                        {
-                            getLog().debug( "Adding dex inputs:" + jarFile );
-                            inputs.add( jarFile.getAbsoluteFile() );
-                        }
-                    }
-                    continue;
+                    // Any jars in the libs folder should now be
+                    // automatically included because they will be a transitive dependency.
                 }
                 else if ( artifact.getType().equals( AAR ) )
                 {
-                    // We need to get the aar classes, not the aar itself.
-                    final File jar = getUnpackedAarClassesJar( artifact );
-                    getLog().debug( "Adding dex input : " + jar );
-                    inputs.add( jar.getAbsoluteFile() );
+                    // The Aar classes.jar should now be automatically included
+                    // because it will be a transitive dependency. As should any jars in the libs folder.
                 }
                 else if ( artifact.getType().equals( APK ) )
                 {


### PR DESCRIPTION
Changed Dex Mojo so that it adds in jars based upon the defined dependencies (including SYSTEM scope deps). This captures all the APKLIB and AAR libs folder jars as well as the AAR classes jars without requiring any special processing. This means that AAR libs folder actually get Dexed into the APK now.

I am a little concerned that removing SYSTEM scope from EXCLUDED_SCOPES might cause some other problem. I haven't run it against the samples yet. If someone could do that I would be much obliged.

Removed noisy log.
