### PR TITLE
Resolves the duplicated resource file aar1JavaResource.txt when building the samples against 544d20d.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -516,8 +516,8 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      * or all types if {@code types} argument is empty
      *
      * @param types artifact types to be selected
-     * @return a {@code List} of all project dependencies. Never {@code null}. This excludes artifacts of the {@code
-     *         EXCLUDED_DEPENDENCY_SCOPES} scopes. And
+     * @return a {@code List} of all project dependencies. Never {@code null}.
+     *         This excludes artifacts of the {@link ArtifactResolverHelper.EXCLUDE_NON_PACKAGED_SCOPES} scopes.
      *         This should maintain dependency order to comply with library project resource precedence.
      */
     protected Set<Artifact> getTransitiveDependencyArtifacts( String... types )
@@ -529,7 +529,8 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
      * Provides transitive dependency artifacts only defined types based on {@code types} argument
      * or all types if {@code types} argument is empty
      *
-     * @param types artifact types to be selected
+     * @param filteredScopes    List of scopes to be removed (ie filtered out).
+     * @param types             Zero or more artifact types to be selected.
      * @return a {@code List} of all project dependencies. Never {@code null}.
      *         This should maintain dependency order to comply with library project resource precedence.
      */
@@ -1142,11 +1143,6 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     protected final File getUnpackedAarClassesJar( Artifact artifact )
     {
         return getUnpackedLibHelper().getUnpackedClassesJar( artifact );
-    }
-
-    protected final File getUnpackedAarJavaResourcesFolder( Artifact artifact )
-    {
-        return new File( getUnpackedLibFolder( artifact ), "java-resources" );
     }
 
     protected final File getUnpackedApkLibSourceFolder( Artifact artifact )

--- a/src/main/java/com/jayway/maven/plugins/android/common/ArtifactResolverHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/ArtifactResolverHelper.java
@@ -32,9 +32,9 @@ import java.util.Set;
 public final class ArtifactResolverHelper
 {
     /**
-     * Which dependency scopes should not be included when unpacking dependencies into the apk.
+     * Which dependency scopes should be excluded when packing dependencies into the apk.
      */
-    protected static final List<String> EXCLUDED_DEPENDENCY_SCOPES = Arrays.asList(
+    public static final List<String> EXCLUDE_NON_PACKAGED_SCOPES = Arrays.asList(
             Artifact.SCOPE_PROVIDED, Artifact.SCOPE_IMPORT
     );
 
@@ -70,7 +70,7 @@ public final class ArtifactResolverHelper
      */
     public Set<Artifact> getFilteredArtifacts( Iterable<Artifact> allArtifacts, String... types )
     {
-        return getFilteredArtifacts( EXCLUDED_DEPENDENCY_SCOPES, allArtifacts, types );
+        return getFilteredArtifacts( EXCLUDE_NON_PACKAGED_SCOPES, allArtifacts, types );
     }
 
     /**

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -480,6 +480,7 @@ public class ApkMojo extends AbstractAndroidMojo
 
         for ( Artifact artifact : getRelevantCompileArtifacts() )
         {
+            getLog().debug( "Found artifact for APK :" + artifact );
             if ( extractDuplicates )
             {
                 try
@@ -497,6 +498,7 @@ public class ApkMojo extends AbstractAndroidMojo
         // Check duplicates.
         if ( extractDuplicates )
         {
+            getLog().debug( "Extracting duplicates" );
             List<String> duplicates = new ArrayList<String>();
             List<File> jarToModify = new ArrayList<File>();
             for ( String s : jars.keySet() )
@@ -519,25 +521,20 @@ public class ApkMojo extends AbstractAndroidMojo
             // Rebuild jars.
             for ( File file : jarToModify )
             {
-                File newJar;
-                newJar = removeDuplicatesFromJar( file, duplicates );
-                int index = jarFiles.indexOf( file );
+                final File newJar = removeDuplicatesFromJar( file, duplicates );
+                getLog().debug( "Removed duplicates from " + newJar );
                 if ( newJar != null )
                 {
+                    final int index = jarFiles.indexOf( file );
                     jarFiles.set( index, newJar );
                 }
-
             }
         }
         
-        String debugKeyStore;
-        ApkBuilder apkBuilder; 
-        try 
+        try
         {
-            debugKeyStore = ApkBuilder.getDebugKeystore();
-            apkBuilder = 
-                    new ApkBuilder( outputFile, zipArchive, dexFile, 
-                            ( signWithDebugKeyStore ) ? debugKeyStore : null, null );
+            final String debugKeyStore = signWithDebugKeyStore ? ApkBuilder.getDebugKeystore() : null;
+            final ApkBuilder apkBuilder = new ApkBuilder( outputFile, zipArchive, dexFile, debugKeyStore, null );
             if ( apkDebug )
             {
                 apkBuilder.setDebugMode( true );
@@ -545,6 +542,7 @@ public class ApkMojo extends AbstractAndroidMojo
 
             for ( File sourceFolder : sourceFolders )
             {
+                getLog().debug( "Adding source folder : " + sourceFolder );
                 apkBuilder.addSourceFolder( sourceFolder );
             }
      
@@ -571,7 +569,7 @@ public class ApkMojo extends AbstractAndroidMojo
                         }
                     }
                 }
-    
+
                 if ( excluded )
                 {
                     continue;
@@ -579,7 +577,8 @@ public class ApkMojo extends AbstractAndroidMojo
                 
                 if ( jarFile.isDirectory() )
                 {
-                    String[] filenames = jarFile.list( new FilenameFilter()
+                    getLog().debug( "Adding resources from jar folder : " + jarFile );
+                    final String[] filenames = jarFile.list( new FilenameFilter()
                     {
                         public boolean accept( File dir, String name )
                         {
@@ -589,17 +588,21 @@ public class ApkMojo extends AbstractAndroidMojo
     
                     for ( String filename : filenames )
                     {
-                        apkBuilder.addResourcesFromJar( new File( jarFile, filename ) );
+                        final File innerJar = new File( jarFile, filename );
+                        getLog().debug( "Adding resources from innerJar : " + innerJar );
+                        apkBuilder.addResourcesFromJar( innerJar );
                     }
                 }
                 else
                 {
+                    getLog().debug( "Adding resources from : " + jarFile );
                     apkBuilder.addResourcesFromJar( jarFile );
                 }
             }
 
             for ( File nativeFolder : nativeFolders )
             {
+                getLog().debug( "Adding native library : " + nativeFolder );
                 apkBuilder.addNativeLibraries( nativeFolder );
             }
             apkBuilder.sealApk();


### PR DESCRIPTION
Manfred, this is the issue you raised on the Dev list.

As I thought, that failure was due to #426 (mea culpa).
This fixes that by not adding the AAR Java resources to the Maven resource path for the project.

NB unless you also merge #435 you will only be able to build the samples  as far as the next project that uses Proguard. (#435 fixes a problem with ProguardMojo).
