### PR TITLE
Resolves missing BuildConfig from APKLIB->APKLIB dependency

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -967,8 +967,8 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
         }
         generateBuildConfigForPackage( packageName );
 
-        // Skip BuildConfig generation for dependencies if this is not an APK project
-        if ( !project.getPackaging().equals( APK ) )
+        // Skip BuildConfig generation for dependencies if this is an AAR project
+        if ( project.getPackaging().equals( AAR ) )
         {
             return;
         }


### PR DESCRIPTION
This resolves issue #434. The change made in #403 was intended for AAR projects, however APKLIB was affected as well. This commit changes the package check when deciding to skip BuildConfig generation of dependencies from !=APK to ==AAR.

New pull request with the changes on a branch. See #437.
