### PR TITLE
use the maven "project.build.directory" instead of hardcode "target"

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/UnpackedLibHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/UnpackedLibHelper.java
@@ -45,7 +45,7 @@ public final class UnpackedLibHelper
     public UnpackedLibHelper( ArtifactResolverHelper artifactResolverHelper, MavenProject project, Logger log )
     {
         this.artifactResolverHelper = artifactResolverHelper;
-        final File targetFolder = new File( project.getBasedir(), "target" );
+        final File targetFolder = new File( project.getBasedir(), project.getBuild().getDirectory() );
         this.unpackedLibsDirectory = new File( targetFolder, "unpacked-libs" );
         this.log = log;
     }


### PR DESCRIPTION
When unpacking Android libraries, use the Maven build directory.

https://github.com/jayway/maven-android-plugin/issues/439
