### PR TITLE
MultiDex support: now secondary dex'es are located directly in apk file,...

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase08preparepackage/DexMojo.java
@@ -39,8 +39,6 @@ import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -63,8 +61,6 @@ import static com.jayway.maven.plugins.android.common.AndroidExtension.APKLIB;
 public class DexMojo extends AbstractAndroidMojo
 {
 
-    private static final String DEX = ".dex";
-    private static final String CLASSES = "classes";
     /**
      * Configuration for the dex command execution. It can be configured in the plugin configuration like so
      *
@@ -210,24 +206,6 @@ public class DexMojo extends AbstractAndroidMojo
         if ( generateApk )
         {
             runDex( executor, outputFile );
-
-            if ( parsedMultiDex )
-            {
-
-                File assets = new File( project.getBuild().getDirectory(),
-                        "generated-sources" + File.separator + "combined-assets" );
-
-                if ( !assets.exists() && !assets.mkdirs() )
-                {
-                    throw new IllegalStateException( "Unable to create combined-assets directory" );
-                }
-                int i = 2;
-                while ( copyAdditionalDex( outputFile, i, assets ) )
-                {
-                   i++;
-                }
-
-            }
         }
 
         if ( attachJar )
@@ -243,28 +221,6 @@ public class DexMojo extends AbstractAndroidMojo
             final File apksources = createApkSourcesFile();
             projectHelper.attachArtifact( project, "apksources", apksources );
         }
-    }
-
-    private boolean copyAdditionalDex( File outputFile, int dexIndex, File assets ) throws MojoExecutionException
-    {
-        File secondDexFile = new File( outputFile, CLASSES + dexIndex + DEX );
-        if ( secondDexFile.exists() )
-        {
-            File copiedSecondDexFile = new File( assets, CLASSES + dexIndex + DEX );
-
-            try
-            {
-                Files.move( secondDexFile.toPath(), copiedSecondDexFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
-
-            }
-            catch ( IOException e )
-            {
-                throw new MojoExecutionException( "IOException while moving classes" + dexIndex + ".dex to "
-                        + "combined-assets directory", e );
-            }
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApkMojo.java
@@ -598,6 +598,8 @@ public class ApkMojo extends AbstractAndroidMojo
                 }
             }
 
+            addSecondaryDexes( dexFile, apkBuilder );
+
             for ( File nativeFolder : nativeFolders )
             {
                 apkBuilder.addNativeLibraries( nativeFolder );
@@ -617,6 +619,21 @@ public class ApkMojo extends AbstractAndroidMojo
         catch ( SealedApkException e )
         {
             throw new MojoExecutionException( e.getMessage() );
+        }
+    }
+
+    private void addSecondaryDexes( File dexFile, ApkBuilder apkBuilder ) throws ApkCreationException,
+            SealedApkException, DuplicateFileException
+    {
+        int dexNumber = 2;
+        String dexFileName = "classes" + dexNumber + ".dex";
+        File secondDexFile = new File( dexFile.getParentFile(), dexFileName );
+        while ( secondDexFile.exists() )
+        {
+            apkBuilder.addFile( secondDexFile, dexFileName );
+            dexNumber++;
+            dexFileName = "classes" + dexNumber + ".dex";
+            secondDexFile = new File( dexFile.getParentFile(), dexFileName );
         }
     }
 


### PR DESCRIPTION
... not in assets (compatible with android.support.MultiDex)

To make this work one should add these lines to main-dex-list file:
android/support/multidex/MultiDex.class
android/support/multidex/MultiDex$V4.class
android/support/multidex/MultiDex$V14.class
android/support/multidex/MultiDex$V19.class
android/support/multidex/MultiDexApplication.class
android/support/multidex/MultiDexExtractor.class
android/support/multidex/MultiDexExtractor$1.class
android/support/multidex/ZipUtil.class
android/support/multidex/ZipUtil$CentralDirectory.class
