### PR TITLE
Lint from the dependency

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Lint.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Lint.java
@@ -13,6 +13,7 @@ public class Lint
     private Boolean failOnError;
     private Boolean skip;
     private Boolean legacy;
+    private Boolean quiet;
 
     // ---------------
     // Enabled Checks
@@ -59,6 +60,11 @@ public class Lint
     public final Boolean isSkip()
     {
         return skip;
+    }
+
+    public final Boolean isQuiet()
+    {
+        return quiet;
     }
 
     public final Boolean isLegacy()

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/LintMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/LintMojo.java
@@ -365,6 +365,13 @@ public class LintMojo extends AbstractAndroidMojo
     @PullParameter( defaultValue = "true" )
     private Boolean parsedLegacy;
 
+    @Parameter( property = "android.lint.quiet" )
+    private Boolean quiet;
+
+    @PullParameter( defaultValue = "true" )
+    private Boolean parsedQuiet;
+
+
     /**
      * Execute the mojo by parsing the config and actually invoking the lint command from the Android SDK.
      *
@@ -378,6 +385,8 @@ public class LintMojo extends AbstractAndroidMojo
         getLog().debug( "Parsed values for Android Lint invocation: " );
         getLog().debug( "failOnError:" + parsedFailOnError );
         getLog().debug( "skip:" + parsedSkip );
+        getLog().debug( "legacy:" + parsedLegacy );
+        getLog().debug( "quiet:" + parsedQuiet );
         getLog().debug( "ignoreWarnings:" + parsedIgnoreWarnings );
         getLog().debug( "warnAll:" + parsedWarnAll );
         getLog().debug( "warningsAsErrors:" + parsedWarningsAsErrors );
@@ -530,12 +539,15 @@ public class LintMojo extends AbstractAndroidMojo
         IssueRegistry registry = new BuiltinIssueRegistry();
 
         LintCliFlags flags = new LintCliFlags();
-        flags.setQuiet( false );
 
         LintCliClient client = new LintCliClient( flags );
 
         try
         {
+            if ( isNotNull( parsedQuiet ) )
+            {
+                flags.setQuiet( parsedQuiet );
+            }
             if ( isNotNull( parsedIgnoreWarnings ) )
             {
                 flags.setIgnoreWarnings( parsedIgnoreWarnings );


### PR DESCRIPTION
Close #357 
Close #400 
Close #476 

This is not activated by default as it currently does not do everything it is supposed to do but it is a start

Use Lint from the dependency instead of the android sdk
