### PR TITLE
Fix release plugin for aar dependencies

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
@@ -255,7 +255,7 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
         }
 
         // Add the classes to the classpath
-        final Dependency dependency = createSystemScopeDependency( artifact, classesJar, "extracted" );
+        final Dependency dependency = createSystemScopeDependency( artifact, classesJar, null );
         project.getModel().addDependency( dependency );
     }
 
@@ -265,6 +265,7 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
         if ( suffix != null )
         {
             artifactId += "_" + suffix;
+            log.debug( "Changing dependency artifactId to: " + artifactId );
         }
         final Dependency dependency = new Dependency();
         dependency.setGroupId( artifact.getGroupId() );


### PR DESCRIPTION
When creating a system scoped depenedency do not add "_expanded" suffix.  When the release plugin performs the prepare goal it will check each dependency's artifactId against the parent artifact's artifactId.  When the suffix is added this check will fail telling the release plugin that the dependency is not part of the reactor and will fail the build