### PR TITLE
Making unpacked-libs folder configurable.

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -494,6 +494,12 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     @Parameter( property = "android.adb.connectionTimeout", defaultValue = "5000" )
     protected int adbConnectionTimeout;
 
+    /**
+     * Folder in which AAR library dependencies will be unpacked.
+     */
+    @Parameter( property = "unpackedLibsFolder", defaultValue = "target/unpacked-libs" )
+    private File unpackedLibsFolder;
+
     private UnpackedLibHelper unpackedLibHelper;
     private ArtifactResolverHelper artifactResolverHelper;
     private NativeHelper nativeHelper;
@@ -1372,7 +1378,8 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
             unpackedLibHelper = new UnpackedLibHelper(
                 getArtifactResolverHelper(),
                 project,
-                new MavenToPlexusLogAdapter( getLog() )
+                new MavenToPlexusLogAdapter( getLog() ),
+                unpackedLibsFolder
             );
         }
         return unpackedLibHelper;

--- a/src/main/java/com/jayway/maven/plugins/android/common/UnpackedLibHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/UnpackedLibHelper.java
@@ -42,11 +42,24 @@ public final class UnpackedLibHelper
     // ${project.build.directory}/unpacked-libs
     private final File unpackedLibsDirectory;
 
-    public UnpackedLibHelper( ArtifactResolverHelper artifactResolverHelper, MavenProject project, Logger log )
+    public UnpackedLibHelper( ArtifactResolverHelper artifactResolverHelper, MavenProject project, Logger log,
+                              File unpackedLibsFolder )
     {
         this.artifactResolverHelper = artifactResolverHelper;
-        final File targetFolder = new File( project.getBuild().getDirectory() );
-        this.unpackedLibsDirectory = new File( targetFolder, "unpacked-libs" );
+        if ( unpackedLibsFolder != null )
+        {
+            // if absolute then use it.
+            // if relative then make it relative to the basedir of the project.
+            this.unpackedLibsDirectory = unpackedLibsFolder.isAbsolute()
+                    ? unpackedLibsFolder
+                    : new File( project.getBasedir(), unpackedLibsFolder.getPath() );
+        }
+        else
+        {
+            // If not specified then default to target/unpacked-libs
+            final File targetFolder = new File( project.getBuild().getDirectory() );
+            this.unpackedLibsDirectory = new File( targetFolder, "unpacked-libs" );
+        }
         this.log = log;
     }
 
@@ -160,6 +173,8 @@ public final class UnpackedLibHelper
                 getShortenedGroupId( artifact.getGroupId() )
                 + "_"
                 + artifact.getArtifactId()
+                + "_"
+                + artifact.getVersion()
         );
     }
 

--- a/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
@@ -65,6 +65,12 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
     private static final boolean INCLUDE_FROM_APKLIB_DEFAULT = false;
     private static final boolean INCLUDE_FROM_AAR_DEFAULT = false;
 
+    /**
+     * Mojo configuration parameter that defines where AAR files should be unpacked.
+     * Default is /target/unpacked-libs
+     */
+    private static final String UNPACKED_LIBS_FOLDER_PARAM = "unpackedLibsFolder";
+
     @Requirement
     private ArtifactResolver artifactResolver;
 
@@ -98,7 +104,12 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
                 continue; // do not modify classpath if not an android project.
             }
 
-            final UnpackedLibHelper helper = new UnpackedLibHelper( artifactResolverHelper, project, log );
+            final String unpackedLibsFolder = PomConfigurationHelper.getPluginConfigParameter(
+                    project, UNPACKED_LIBS_FOLDER_PARAM, null );
+            log.debug( UNPACKED_LIBS_FOLDER_PARAM + " set to " + unpackedLibsFolder );
+            final UnpackedLibHelper helper = new UnpackedLibHelper( artifactResolverHelper, project, log,
+                    unpackedLibsFolder == null ? null : new File( unpackedLibsFolder )
+            );
 
             final Set<Artifact> artifacts;
 


### PR DESCRIPTION
I've noticed lately (perhaps since upgrading to IntelliJ 14.0.2?? though I think it was happening before that) that IntelliJ is placing a file lock on the AAR dependency jar files (ie classes.jar and whatever matches libs/*.jar) that have been exctrated into target/unpacked-libs/

This means that mvn clean fails - which sucks.

I can understand why IntelliJ might do that as it provides auto complete based upon classes in the classpath. So I don't really think it is IntelliJ's fault.

One way of dealing is to allow that unpacked-libs folder to be configurable so that it could be placed outside of /target. 

This PR provides an unpackedLibsFolder parameter (default remains /target/unpacked-libs) that specifies where the unpacked libs will be placed.
I also changed the UnpackedLibHelper to append the unpacked-lib's version to the libs folder name.
