### PR TITLE
Deprecate APKLIB - Replaced by AAR

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/AndroidExtension.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/AndroidExtension.java
@@ -12,7 +12,9 @@ public final class AndroidExtension
 
     /**
      * Android library project as created by Android Maven Plugin.
+     * @deprecated Use {@link AAR} instead.
      */
+    @Deprecated
     public static final String APKLIB = "apklib";
 
     /**

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/Apk.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/Apk.java
@@ -17,7 +17,7 @@ public class Apk
     private String[] metaIncludes;
 
     /**
-     * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ApkMojo#apkMetaInf}.
+     * Mirror of {@link com.jayway.maven.plugins.android.phase09package.ApkMojo#apkMetaInf}.
      */
     private MetaInf  metaInf;
 

--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/ApklibMojo.java
@@ -51,7 +51,9 @@ import static com.jayway.maven.plugins.android.common.AndroidExtension.APKLIB;
  * apklib files do not generate deployable artifacts.
  *
  * @author nmaiorana@gmail.com
+ * @deprecated Use Aar instead see {@link com.jayway.maven.plugins.android.phase09package.AarMojo}
  */
+@Deprecated
 @Mojo( name = "apklib", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE )
 public class ApklibMojo extends AbstractAndroidMojo
 {


### PR DESCRIPTION
I think we should deprecated apklib in the next release because when someone has issues with apklib we all seem to tell him to use Aar instead.

If you all agree then we can merge this.
