### PR TITLE
Deprecate MergeManifest Parameter from the GenerateSourcesMojo as it is ...

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -166,7 +166,10 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
      *     &lt;/resource&gt;
      * &lt;/resources&gt;
      * </pre>
+     * @deprecated Use ManifestMerger v2 instead
+     * {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo}
      */
+    @Deprecated
     @Parameter( property = "android.mergeManifests", defaultValue = "false" )
     protected boolean mergeManifests;
 
@@ -1047,6 +1050,12 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
         }
     }
 
+    /**
+     * @deprecated Use ManifestMerger v2 instead
+     * {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo}
+     * @throws MojoExecutionException
+     */
+    @Deprecated
     private void mergeManifests() throws MojoExecutionException
     {
         getLog().debug( "mergeManifests: " + mergeManifests );

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -68,7 +68,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
      *             &lt;usesSdk&gt;
      *               &lt;minSdkVersion&gt;14&lt;/minSdkVersion&gt;
      *               &lt;targetSdkVersion&gt;21&lt;/targetSdkVersion&gt;
-     *             &lt;/versionCode&gt;
+     *             &lt;/usesSdk&gt;
      *           &lt;/manifestMerger&gt;
      *         &lt;/configuration&gt;
      *       &lt;/execution&gt;

--- a/src/test/projects/tictactoe/pom.xml
+++ b/src/test/projects/tictactoe/pom.xml
@@ -10,7 +10,7 @@
   <name>TicTacToe - Parent</name>
   <properties>
     <!-- at test time this will be overridden with snapshot version -->
-    <it-plugin.version>4.0.0</it-plugin.version>
+    <it-plugin.version>4.1.0</it-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -44,12 +44,11 @@
 
         <plugin>
           <groupId>com.simpligility.maven.plugins</groupId>
-
           <artifactId>android-maven-plugin</artifactId>
           <version>${it-plugin.version}</version>
           <configuration>
             <sdk>
-              <platform>19</platform>
+              <platform>21</platform>
             </sdk>
             <emulator>
               <avd>23</avd>

--- a/src/test/projects/tictactoe/tictactoe-app/pom.xml
+++ b/src/test/projects/tictactoe/tictactoe-app/pom.xml
@@ -16,6 +16,9 @@
 
   <properties>
     <environment>development</environment>
+    <android.versionCode>42</android.versionCode>
+    <android.minSdk>14</android.minSdk>
+    <android.targetSdk>21</android.targetSdk>
   </properties>
 
   <dependencies>
@@ -42,16 +45,30 @@
     <plugins>
       <plugin>
         <groupId>com.simpligility.maven.plugins</groupId>
-
         <artifactId>android-maven-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
           <!--<extractDuplicates>true</extractDuplicates> -->
-          <mergeManifests>true</mergeManifests>
-          <manifest>
-            <debuggable>true</debuggable>
-          </manifest>
+          <manifestMerger>
+            <versionCode>${android.versionCode}</versionCode>
+            <versionCodeUpdateFromVersion>false</versionCodeUpdateFromVersion>
+            <usesSdk>
+              <minSdkVersion>${android.minSdk}</minSdkVersion>
+              <targetSdkVersion>${android.targetSdk}</targetSdkVersion>
+            </usesSdk>
+            <mergeLibraries>true</mergeLibraries>
+            <mergeReportFile>${project.build.directory}/ManifestMergeReport.txt</mergeReportFile>
+          </manifestMerger>
         </configuration>
+        <executions>
+          <execution>
+            <id>manifestMerger</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>manifest-merger</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -120,7 +137,6 @@
             proguard and we run the manifest update -->
           <plugin>
             <groupId>com.simpligility.maven.plugins</groupId>
-
             <artifactId>android-maven-plugin</artifactId>
             <inherited>true</inherited>
             <configuration>
@@ -135,10 +151,16 @@
                 <outputApk>${project.build.directory}/${project.artifactId}-signed-aligned.apk
                 </outputApk>
               </zipalign>
-              <manifest>
-                <debuggable>false</debuggable>
-                <versionCodeAutoIncrement>true</versionCodeAutoIncrement>
-              </manifest>
+              <manifestMerger>
+                <versionCode>${android.versionCode}</versionCode>
+                <versionCodeUpdateFromVersion>false</versionCodeUpdateFromVersion>
+                <usesSdk>
+                  <minSdkVersion>${android.minSdk}</minSdkVersion>
+                  <targetSdkVersion>${android.targetSdk}</targetSdkVersion>
+                </usesSdk>
+                <mergeLibraries>true</mergeLibraries>
+                <mergeReportFile>${project.build.directory}/ManifestMergeReport.txt</mergeReportFile>
+              </manifestMerger>
               <proguard>
                 <skip>false</skip>
               </proguard>
@@ -147,10 +169,10 @@
             </configuration>
             <executions>
               <execution>
-                <id>manifestUpdate</id>
+                <id>manifestMerger</id>
                 <phase>process-resources</phase>
                 <goals>
-                  <goal>manifest-update</goal>
+                  <goal>manifest-merger</goal>
                 </goals>
               </execution>
               <execution>

--- a/src/test/projects/tictactoe/tictactoe-app/src/main/AndroidManifest.xml
+++ b/src/test/projects/tictactoe/tictactoe-app/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (C) 2010 The Android Open Source Project
  *
@@ -12,7 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
---><manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.android.tictactoe">
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.example.android.tictactoe">
 
     <uses-sdk android:minSdkVersion="8"/>
 
@@ -23,6 +25,5 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name="com.example.android.tictactoe.library.GameActivity"/>
     </application>
 </manifest>


### PR DESCRIPTION
...replaced by the Manifest Merger v2.

Fixed javadoc tag
Added usage example of the Manifest Merger V2 (tictactoe)


@mosabua can you sign this off ? no functionality changes, 1 deprecation and 1 example