### PR TITLE
Work-around for manifest merger (v2) messing up certain CRLF EOL markers

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/common/AndroidManifestEOLHelper.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/AndroidManifestEOLHelper.java
@@ -1,0 +1,119 @@
+package com.jayway.maven.plugins.android.common;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Helper class to deal with end-of-line issues in AndroidManifest.xml files.
+ * Used by ManifestMergerMojo, ManifestUpdateMojo, and GenerateSourcesMojo.
+ * 
+ * @see https://github.com/simpligility/android-maven-plugin/issues/511
+ * 
+ * @author Matthias Stevens <matthias.stevens@gmail.com>
+ */
+public class AndroidManifestEOLHelper
+{
+
+    private final File mainManifestFile;
+    private final boolean sourceFile;
+    private final File targetDirectory;
+    private final Log log;
+    private final boolean hasWindowsLineEndings;
+    private File tempFile; 
+    
+    /**
+     * @param mainManifestFile
+     * @param sourceFile whether or not the mainManifestFile is the source file (not to be modified) or not
+     * @param targetDirectory
+     * @param log
+     */
+    public AndroidManifestEOLHelper( File mainManifestFile, boolean sourceFile, File targetDirectory, Log log )
+    {
+        this.mainManifestFile = mainManifestFile;
+        this.sourceFile = sourceFile;
+        this.targetDirectory = targetDirectory;
+        this.log = log;
+        boolean crlf = false;
+        try
+        {
+            crlf = EOLUtils.hasWindowsEOL( mainManifestFile );
+        }
+        catch ( Exception e )
+        {
+            log.warn( e );
+        }
+        this.hasWindowsLineEndings = crlf;
+    }
+    
+    /**
+     * Returns manifest file with Unix-style line endings (LF).
+     * If the mainManifest has Windows-style line endings (CRLF) it, or a temporary copy,
+     * will be converted to have Unix-style line endings (LF).
+     * 
+     * @return manifest file with Unix-style line endings (LF)
+     */
+    public File getUnixEOLManifestFile()
+    {
+        // Convert to Unix-style line endings (LF) if needed:        
+        if ( hasWindowsLineEndings )
+        {
+            log.info( "Windows-style line-endings detected, converting to Unix-style line endings "
+                      + "to avoid that the manifest merger messes things up..." );
+            try
+            {
+                File manifestFileLF;
+                if ( sourceFile )
+                {
+                    // Create temp file:
+                    manifestFileLF = new File( targetDirectory, "AndroidManifest_LF_EOL.xml" );
+                    FileUtils.copyFile( mainManifestFile, manifestFileLF );
+                    tempFile = manifestFileLF;
+                }
+                else
+                {
+                    manifestFileLF = mainManifestFile; // use main file if it is not the source manifest
+                }
+                // Convert line endings:
+                EOLUtils.convertToUnixEOL( manifestFileLF );
+                // Return manifest with LF line endings:
+                return manifestFileLF;
+            }
+            catch ( IOException ioe )
+            {
+                log.warn( "Failed to convert manifest file line endings from CRLF to LF", ioe );
+            }
+        }
+        return mainManifestFile; // use unchanged manifest
+    }
+    
+    /**
+     * Converts line-ending in given manifest file back to Windows-style (CRLF), if needed.
+     * Also deletes the temp file, if one was created in {@link #getUnixEOLManifestFile()}.
+     * 
+     * @param destinationManifestFile
+     */
+    public void restoreEOL( File destinationManifestFile )
+    {
+        if ( hasWindowsLineEndings )
+        {
+            log.info( "Converting back to Windows-style line-endings..." );
+            try
+            {
+                EOLUtils.convertToWindowsEOL(  destinationManifestFile );
+            }
+            catch ( IOException ioe )
+            {
+                log.warn( "Failed to convert manifest file line endings from LF to CRLF", ioe );
+            }
+            // Delete temp file if there is one and it is not the destination file:
+            if ( ! destinationManifestFile.equals( tempFile ) )
+            {
+                FileUtils.deleteQuietly( tempFile );
+            }
+        }
+    }
+        
+}

--- a/src/main/java/com/jayway/maven/plugins/android/common/EOLUtils.java
+++ b/src/main/java/com/jayway/maven/plugins/android/common/EOLUtils.java
@@ -1,0 +1,307 @@
+package com.jayway.maven.plugins.android.common;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Helper class to deal with end-of-line markers in text files.
+ * 
+ * Loosely based on these examples:
+ *  - http://stackoverflow.com/a/9456947/1084488 (cc by-sa 3.0)
+ *  - http://svn.apache.org/repos/asf/tomcat/trunk/java/org/apache/tomcat/buildutil/CheckEol.java (Apache License v2.0)
+ * 
+ * This file is posted here to meet the "ShareAlike" requirement of cc by-sa 3.0:
+ *    http://stackoverflow.com/a/27930311/1084488
+ * 
+ * @author Matthias Stevens <matthias.stevens@gmail.com>
+ */
+public class EOLUtils
+{
+
+    /**
+     * Unix-style end-of-line marker (LF)
+     */
+    private static final String EOL_UNIX = "\n";
+
+    /**
+     * Windows-style end-of-line marker (CRLF)
+     */
+    private static final String EOL_WINDOWS = "\r\n";
+
+    /**
+     * "Old Mac"-style end-of-line marker (CR)
+     */
+    private static final String EOL_OLD_MAC = "\r";
+
+    /**
+     * Default end-of-line marker on current system
+     */
+    private static final String EOL_SYSTEM_DEFAULT = System.getProperty( "line.separator" );
+
+    /**
+     * The support end-of-line marker modes
+     */
+    public static enum Mode
+    {
+        /**
+         * Unix-style end-of-line marker ("\n")
+         */
+        LF,
+
+        /**
+         * Windows-style end-of-line marker ("\r\n") 
+         */
+        CRLF,
+
+        /**
+         * "Old Mac"-style end-of-line marker ("\r")
+         */
+        CR
+    }
+
+    /**
+     * The default end-of-line marker mode for the current system
+     */
+    public static final Mode SYSTEM_DEFAULT = ( EOL_SYSTEM_DEFAULT.equals( EOL_UNIX ) ? Mode.LF : ( EOL_SYSTEM_DEFAULT
+        .equals( EOL_WINDOWS ) ? Mode.CRLF : ( EOL_SYSTEM_DEFAULT.equals( EOL_OLD_MAC ) ? Mode.CR : null ) ) );
+    static
+    {
+        // Just in case...
+        if ( SYSTEM_DEFAULT == null )
+        {
+            throw new IllegalStateException( "Could not determine system default end-of-line marker" );
+        }
+    }
+
+    /**
+     * Determines the end-of-line {@link Mode} of a text file.
+     * 
+     * @param textFile the file to investigate
+     * @return the end-of-line {@link Mode} of the given file, or {@code null} if it could not be determined
+     * @throws Exception
+     */
+    public static Mode determineEOL( File textFile )
+        throws Exception
+    {
+        if ( !textFile.exists() )
+        {
+            throw new IOException( "Could not find file to open: " + textFile.getAbsolutePath() );
+        }
+
+        FileInputStream fileIn = new FileInputStream( textFile );
+        BufferedInputStream bufferIn = new BufferedInputStream( fileIn );
+        try
+        {
+            int prev = -1;
+            int ch;
+            while ( ( ch = bufferIn.read() ) != -1 )
+            {
+                if ( ch == '\n' )
+                {
+                    if ( prev == '\r' )
+                    {
+                        return Mode.CRLF;
+                    }
+                    else
+                    {
+                        return Mode.LF;
+                    }
+                }
+                else if ( prev == '\r' )
+                {
+                    return Mode.CR;
+                }
+                prev = ch;
+            }
+            throw new Exception( "Could not determine end-of-line marker mode" );
+        }
+        catch ( IOException ioe )
+        {
+            throw new Exception( "Could not determine end-of-line marker mode", ioe );
+        }
+        finally
+        {
+            // Clean up:
+            IOUtils.closeQuietly( bufferIn );
+        }
+    }
+
+    /**
+     * Checks whether the given text file has Windows-style (CRLF) line endings.
+     * 
+     * @param textFile the file to investigate
+     * @return
+     * @throws Exception
+     */
+    public static boolean hasWindowsEOL( File textFile )
+        throws Exception
+    {
+        return Mode.CRLF.equals( determineEOL( textFile ) );
+    }
+
+    /**
+     * Checks whether the given text file has Unix-style (LF) line endings.
+     * 
+     * @param textFile the file to investigate
+     * @return
+     * @throws Exception
+     */
+    public static boolean hasUnixEOL( File textFile )
+        throws Exception
+    {
+        return Mode.LF.equals( determineEOL( textFile ) );
+    }
+
+    /**
+     * Checks whether the given text file has "Old Mac"-style (CR) line endings.
+     * 
+     * @param textFile the file to investigate
+     * @return
+     * @throws Exception
+     */
+    public static boolean hasOldMacEOL( File textFile )
+        throws Exception
+    {
+        return Mode.CR.equals( determineEOL( textFile ) );
+    }
+
+    /**
+     * Checks whether the given text file has line endings that conform to the system default mode (e.g. LF on Unix).
+     * 
+     * @param textFile the file to investigate
+     * @return
+     * @throws Exception
+     */
+    public static boolean hasSystemDefaultEOL( File textFile )
+        throws Exception
+    {
+        return SYSTEM_DEFAULT.equals( determineEOL( textFile ) );
+    }
+
+    /**
+     * Convert the line endings in the given file to Unix-style (LF).
+     * 
+     * @param textFile the file to process
+     * @throws IOException
+     */
+    public static void convertToUnixEOL( File textFile )
+        throws IOException
+    {
+        convertLineEndings( textFile, EOL_UNIX );
+    }
+
+    /**
+     * Convert the line endings in the given file to Windows-style (CRLF).
+     * 
+     * @param textFile the file to process
+     * @throws IOException
+     */
+    public static void convertToWindowsEOL( File textFile )
+        throws IOException
+    {
+        convertLineEndings( textFile, EOL_WINDOWS );
+    }
+
+    /**
+     * Convert the line endings in the given file to "Old Mac"-style (CR).
+     * 
+     * @param textFile the file to process
+     * @throws IOException
+     */
+    public static void convertToOldMacEOL( File textFile )
+        throws IOException
+    {
+        convertLineEndings( textFile, EOL_OLD_MAC );
+    }
+
+    /**
+     * Convert the line endings in the given file to the system default mode.
+     * 
+     * @param textFile the file to process
+     * @throws IOException
+     */
+    public static void convertToSystemEOL( File textFile )
+        throws IOException
+    {
+        convertLineEndings( textFile, EOL_SYSTEM_DEFAULT );
+    }
+
+    /**
+     * Line endings conversion method.
+     * 
+     * @param textFile the file to process
+     * @param eol the end-of-line marker to use (as a {@link String})
+     * @throws IOException 
+     */
+    private static void convertLineEndings( File textFile, String eol )
+        throws IOException
+    {
+        File temp = null;
+        BufferedReader bufferIn = null;
+        BufferedWriter bufferOut = null;
+
+        try
+        {
+            if ( textFile.exists() )
+            {
+                // Create a new temp file to write to
+                temp = new File( textFile.getAbsolutePath() + ".normalized" );
+                temp.createNewFile();
+
+                // Get a stream to read from the file un-normalized file
+                FileInputStream fileIn = new FileInputStream( textFile );
+                DataInputStream dataIn = new DataInputStream( fileIn );
+                bufferIn = new BufferedReader( new InputStreamReader( dataIn ) );
+
+                // Get a stream to write to the normalized file
+                FileOutputStream fileOut = new FileOutputStream( temp );
+                DataOutputStream dataOut = new DataOutputStream( fileOut );
+                bufferOut = new BufferedWriter( new OutputStreamWriter( dataOut ) );
+
+                // For each line in the un-normalized file
+                String line;
+                while ( ( line = bufferIn.readLine() ) != null )
+                {
+                    // Write the original line plus the operating-system dependent newline
+                    bufferOut.write( line );
+                    bufferOut.write( eol ); // write EOL marker
+                }
+
+                // Close buffered reader & writer:
+                bufferIn.close();
+                bufferOut.close();
+
+                // Remove the original file
+                textFile.delete();
+
+                // And rename the original file to the new one
+                temp.renameTo( textFile );
+            }
+            else
+            {
+                // If the file doesn't exist...
+                throw new IOException( "Could not find file to open: " + textFile.getAbsolutePath() );
+            }
+        }
+        finally
+        {
+            // Clean up, temp should never exist
+            FileUtils.deleteQuietly( temp );
+            IOUtils.closeQuietly( bufferIn );
+            IOUtils.closeQuietly( bufferOut );
+        }
+    }
+
+}

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -308,8 +308,10 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
                            + "to avoid that the manifest merger messes things up..." );
             try
             {
+                // Create temp file:
                 androidManifestFileLF = new File( targetDirectory, "AndroidManifest_LF_EOL.xml" );
                 FileUtils.copyFile( androidManifestFile, androidManifestFileLF );
+                // Convert line endings:
                 EOLUtils.convertToUnixEOL( androidManifestFileLF );
             }
             catch ( IOException ioe )
@@ -339,6 +341,8 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
             {
                 getLog().warn( "Failed to convert manifest file line endings from LF to CRLF", ioe );
             }
+            // Delete temp file:
+            FileUtils.deleteQuietly( androidManifestFileLF );
         }
     }
 


### PR DESCRIPTION
Work-around manifest update and merging messing up certain `CRLF` EOL markers -- fixes #511

**Problem:** When fed a manifest file with Windows-style line endings (`CRLF`) the ManifestMergerMojo replaces certain `CRLF` occurrences (specifically in multi-line XML comments) with Unix-style `LF` line endings, leaving the file with inconsistent line endings. The GenerateSourcesMojo and the (deprecated) ManifestUpdateMojo exhibit the same problem.
Because the ManifestMergerMojo relies on the Android builder library the problem should actually be tackled there (bug report: https://code.google.com/p/android/issues/detail?id=96992). But in the meantime, here is a stopgap solution...

**Work-around being committed:** In all 3 affected Mojos the I have added code to check whether the input manifest file has `CRLF` line endings, if it does I convert the file (or a temporary copy of it) to have `LF` line endings throughout and only then processes (update/merge) it. After processing the resulting (destination) manifest file is converted back to have `CRLF` line endings if the original  file had them.