### PR TITLE
Improvement of versionCode generator

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/ManifestMerger.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/ManifestMerger.java
@@ -35,6 +35,18 @@ public class ManifestMerger
 
     /**
      * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
+     * #manifestMergerVersionElements}.
+     */
+    protected Integer versionElements;
+
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
+     * #manifestMergerVersionElementDigits}.
+     */
+    protected Integer versionElementDigits;
+
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
      * #manifestMergeLibraries}.
      */
     protected Boolean mergeLibraries;
@@ -63,6 +75,17 @@ public class ManifestMerger
     public Boolean getVersionCodeUpdateFromVersion()
     {
         return versionCodeUpdateFromVersion;
+    }
+
+    
+    public Integer getVersionElements()
+    {
+        return versionElements;
+    }
+
+    public Integer getVersionElementDigits()
+    {
+        return versionElementDigits;
     }
 
     public Boolean getMergeLibraries()

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
@@ -1,0 +1,52 @@
+
+package com.jayway.maven.plugins.android.configuration;
+
+import static java.lang.String.format;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+public class VersionGenerator
+{
+
+    private int elementsCount;
+
+    private int multiplier;
+
+    public VersionGenerator( int elementsCount, int elementDigits )
+    {
+        this.elementsCount = elementsCount;
+        this.multiplier = (int) Math.pow( 10, elementDigits );
+    }
+
+    public int generate( String versionName ) throws MojoExecutionException
+    {
+        String[] versionNameElements = versionName.replaceAll( "[^0-9.]", "" ).split( "\\." );
+
+        long versionCode = 0;
+
+        for ( int i = 0; i < elementsCount; i++ )
+        {
+            versionCode *= multiplier;
+
+            if ( i < versionNameElements.length )
+            {
+                String versionElement = versionNameElements[i];
+                int elementValue = Integer.valueOf( versionElement );
+
+                if ( i > 0 && elementValue >= multiplier )
+                {
+                    throw new MojoExecutionException( format( "The version element is too large: %d", elementValue ) );
+                }
+
+                versionCode += elementValue;
+            }
+        }
+
+        if ( versionCode > Integer.MAX_VALUE )
+        {
+            throw new MojoExecutionException( format( "The version code is too large: %d", versionCode ) );
+        }
+
+        return (int) versionCode;
+    }
+}

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
@@ -1,0 +1,61 @@
+
+package com.jayway.maven.plugins.android.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VersionGeneratorTest
+{
+
+    @Test
+    public void generate() throws MojoExecutionException
+    {
+        assertEquals( 2146999999, new VersionGenerator( 3, 3 ).generate( "2146.999.999" ) );
+        assertEquals( 2147483647, new VersionGenerator( 3, 3 ).generate( "2147.483.647" ) );
+
+        // that's weird versioning scheme :)
+        assertEquals( 2147483647, new VersionGenerator( 10, 1 ).generate( "2.1.4.7.4.8.3.6.4.7" ) );
+
+        assertTrue( new VersionGenerator( 3, 3 ).generate( "1.0" ) < new VersionGenerator( 3, 3 ).generate( "1.0.1" ) );
+        assertTrue( new VersionGenerator( 3, 2 ).generate( "1.0" ) < new VersionGenerator( 3, 2 ).generate( "1.0.1" ) );
+    }
+
+    @Test
+    public void maxVersionCode() throws MojoExecutionException
+    {
+        try
+        {
+            new VersionGenerator( 3, 3 ).generate( "2200.999.999" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+
+        try
+        {
+            new VersionGenerator( 4, 3 ).generate( "2200.999.999" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+
+        try
+        {
+            new VersionGenerator( 3, 3 ).generate( "1.1000.999" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+    }
+}

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
@@ -23,6 +23,8 @@ public class VersionGeneratorTest
 
         assertTrue( new VersionGenerator( 3, 3 ).generate( "1.0" ) < new VersionGenerator( 3, 3 ).generate( "1.0.1" ) );
         assertTrue( new VersionGenerator( 3, 2 ).generate( "1.0" ) < new VersionGenerator( 3, 2 ).generate( "1.0.1" ) );
+        assertTrue( new VersionGenerator( 3, 3 ).generate( "2.0" ) > new VersionGenerator( 3, 3 ).generate( "1.0.1" ) );
+        assertTrue( new VersionGenerator( 3, 2 ).generate( "2.0" ) > new VersionGenerator( 3, 2 ).generate( "1.0.1" ) );
     }
 
     @Test


### PR DESCRIPTION
The current version generator acts wrongly if the version "1.0" is followed by "1.0.1" then "2.0".

Added a configurable version generator where the number of elements and the number of digits per element are configurable.