### PR TITLE
Improvement of versionCode generator

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/ManifestMerger.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/ManifestMerger.java
@@ -35,6 +35,12 @@ public class ManifestMerger
 
     /**
      * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
+     * #manifestVersionDigits}.
+     */
+    protected String versionDigits;
+
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
      * #manifestMergeLibraries}.
      */
     protected Boolean mergeLibraries;
@@ -63,6 +69,11 @@ public class ManifestMerger
     public Boolean getVersionCodeUpdateFromVersion()
     {
         return versionCodeUpdateFromVersion;
+    }
+
+    public String getVersionDigits()
+    {
+        return versionDigits;
     }
 
     public Boolean getMergeLibraries()

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
@@ -1,0 +1,76 @@
+
+package com.jayway.maven.plugins.android.configuration;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import static java.lang.String.format;
+
+public class VersionGenerator
+{
+
+    private final int elementsCount;
+
+    private final int[] multipliers;
+
+    public VersionGenerator()
+    {
+        this( "4,3,3" );
+    }
+
+    public VersionGenerator( String versionDigits )
+    {
+        final String[] digits = versionDigits.split( "[,;]" );
+
+        this.elementsCount = digits.length;
+        this.multipliers = new int[this.elementsCount];
+
+        int total = 0;
+
+        for ( int k = 0; k < this.elementsCount; k++ )
+        {
+            int value = Integer.valueOf( digits[k].trim() );
+
+            total += value;
+
+            this.multipliers[k] = (int) Math.pow( 10, value );
+        }
+
+        if ( total < 1 || total > 10 )
+        {
+            throw new IllegalArgumentException( format( "Invalid number of digits, got %d", total ) );
+        }
+    }
+
+    public int generate( String versionName ) throws MojoExecutionException
+    {
+        final String[] versionNameElements = versionName.replaceAll( "[^0-9.]", "" ).split( "\\." );
+
+        long versionCode = 0;
+
+        for ( int k = 0; k < this.elementsCount; k++ )
+        {
+            versionCode *= this.multipliers[k];
+
+            if ( k < versionNameElements.length )
+            {
+                final String versionElement = versionNameElements[k];
+                final int elementValue = Integer.valueOf( versionElement );
+
+                if ( elementValue >= this.multipliers[k] )
+                {
+                    throw new MojoExecutionException( format( "The version element is too large: %d, max %d",
+                        elementValue, this.multipliers[k] - 1 ) );
+                }
+
+                versionCode += elementValue;
+            }
+        }
+
+        if ( versionCode > Integer.MAX_VALUE )
+        {
+            throw new MojoExecutionException( format( "The version code is too large: %d", versionCode ) );
+        }
+
+        return (int) versionCode;
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
@@ -5,6 +5,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 import static java.lang.String.format;
 
+/**
+ * @author Pappy STĂNESCU <a href="mailto:pappy.stanescu&#64;gmail.com">&lt;pappy.stanescu&#64;gmail.com&gt;</a>
+ */
 public class VersionGenerator
 {
 

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
@@ -9,6 +9,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+/**
+ * @author Pappy STĂNESCU <a href="mailto:pappy.stanescu&#64;gmail.com">&lt;pappy.stanescu&#64;gmail.com&gt;</a>
+ */
 public class VersionGeneratorTest
 {
 

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
@@ -46,6 +46,22 @@ public class VersionGeneratorTest
     }
 
     @Test
+    public void mixedCase() throws MojoExecutionException
+    {
+        VersionGenerator g1 = new VersionGenerator( "1,1,2,1,4" );
+        VersionGenerator g2 = new VersionGenerator( "1,1,2,5" );
+        
+        int v1 = g1.generate( "1.2.15.8-SNAPSHOT.1946" );
+        int v2 = g2.generate( "2.1.6-SNAPSHOT.1246" );
+        
+        assertEquals(121581946, v1 );
+        assertEquals(210601246, v2 );
+
+        assertTrue( v1 < v2 );
+
+    }
+
+    @Test
     public void faulty() throws MojoExecutionException
     {
         try

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
@@ -1,0 +1,90 @@
+
+package com.jayway.maven.plugins.android.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VersionGeneratorTest
+{
+
+    @Test
+    public void generate() throws MojoExecutionException
+    {
+        assertEquals( 2147483647, new VersionGenerator( "1,2,3,4" ).generate( "2.14.748.3647" ) );
+        assertEquals( 2147483647, new VersionGenerator( "4,3,2,1" ).generate( "2147.483.64.7" ) );
+
+        // that's weird versioning scheme :)
+        assertEquals( 2147483647, new VersionGenerator( "1,1,1,1,1,1,1,1,1,1" ).generate( "2.1.4.7.4.8.3.6.4.7" ) );
+    }
+
+    @Test
+    public void compare() throws MojoExecutionException {
+        VersionGenerator gen = new VersionGenerator( "3,3,3" );
+    
+        assertTrue( gen.generate( "1.0" ) < gen.generate( "1.0.1" ) );
+        assertTrue( gen.generate( "2.0" ) > gen.generate( "1.0.1" ) );
+   }
+
+    @Test
+    public void realCase() throws MojoExecutionException
+    {
+        VersionGenerator gen = new VersionGenerator( "1,1,2,1,4" );
+        
+        int v1 = gen.generate( "4.1.16.8-SNAPSHOT.1946" );
+        int v2 = gen.generate( "4.1.17.8-SNAPSHOT.1246" );
+        
+        assertEquals(411681946, v1 );
+        assertEquals(411781246, v2 );
+
+        assertTrue( v1 < v2 );
+
+    }
+
+    @Test
+    public void faulty() throws MojoExecutionException
+    {
+        try
+        {
+            new VersionGenerator( "4,4,4" );
+            fail( "Expecting IllegalArgumentException" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+        try
+        {
+            new VersionGenerator( "4,3,3" ).generate( "2200.999.999" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+
+        try
+        {
+            new VersionGenerator( "4,3,3" ).generate( "2200.999.999" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+
+        try
+        {
+            new VersionGenerator( "4,3,3" ).generate( "1.1000.999" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+    }
+}


### PR DESCRIPTION
The current version generator acts wrongly if the version "1.0" is
followed by "1.0.1", "2.0".

Added a configurable version generator where the number of elements and
the number of digits per element are configurable through a version
spec. The spec is a comma-separated list of digits, one for each version
element.