### PR TITLE
Prevent native libraries from transitive dependencies being added to aar

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase09package/AarMojo.java
@@ -271,17 +271,6 @@ public class AarMojo extends AbstractAndroidMojo
                     //        libraries from dependencies of the AAR
                     //final File dependentLibs = new File( ndkOutputDirectory.getAbsolutePath(), ndkArchitecture );
                     //addSharedLibraries( jarArchiver, dependentLibs, prefix );
-
-                    // get native libs from other aars and apklibs
-                    for ( Artifact libraryArtifact : getTransitiveDependencyArtifacts( APKLIB, AAR ) )
-                    {
-                        final File apklibLibsDirectory = new File(
-                                getUnpackedLibNativesFolder( libraryArtifact ), architecture );
-                        if ( apklibLibsDirectory.exists() )
-                        {
-                            addSharedLibraries( zipArchiver, apklibLibsDirectory, architecture );
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
This should fix the problem described in #477