### PR TITLE
Change maven prerequisite to 3.0.4 to match the maven api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 
   <prerequisites>
     <!-- define the version need to run this plugin -->
-    <maven>3.0.5</maven>
+    <maven>3.0.4</maven>
   </prerequisites>
 
   <dependencyManagement>


### PR DESCRIPTION
I believe this change was missed for this commit:
https://github.com/simpligility/android-maven-plugin/commit/c139368dc3643e20c31f78fb1ed42bc80fb31611
