### PR TITLE
Configurable encoding for listing text files

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractAndroidMojo.java
@@ -178,6 +178,12 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     protected File resourceDirectory;
 
     /**
+     * The project source encoding. It will use the platform default encoding if the property is not set.
+     */
+    @Parameter( defaultValue = "${project.build.sourceEncoding}", readonly = true )
+    protected String sourceEncoding;
+    
+    /**
      * Override default generated folder containing R.java
      */
     @Parameter( property = "android.genDirectory", defaultValue = "${project.build.directory}/generated-sources/r" )

--- a/src/main/java/com/jayway/maven/plugins/android/AbstractPublisherMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/AbstractPublisherMojo.java
@@ -4,14 +4,17 @@ import com.android.annotations.NonNull;
 import com.google.api.services.androidpublisher.AndroidPublisher;
 import com.google.api.services.androidpublisher.model.AppEdit;
 import com.jayway.maven.plugins.android.common.AndroidPublisherHelper;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,7 +71,18 @@ public abstract class AbstractPublisherMojo extends AbstractAndroidMojo
     public String readFile( File file, int maxChars ) throws IOException
     {
         String everything;
-        BufferedReader br = new BufferedReader( new FileReader( file ) );
+        InputStreamReader isr;
+        
+        if ( sourceEncoding == null )
+        {
+            isr = new InputStreamReader( new FileInputStream( file ) ); // platform default encoding
+        }
+        else
+        {
+            isr = new InputStreamReader( new FileInputStream( file ), sourceEncoding );
+        }
+        
+        BufferedReader br = new BufferedReader( isr );
         try
         {
             StringBuilder sb = new StringBuilder();
@@ -135,6 +149,17 @@ public abstract class AbstractPublisherMojo extends AbstractAndroidMojo
         {
             getLog().warn( errorMessage + " - Filename: " + fileName );
             return null;
+        }
+    }
+    
+    protected void warnPlatformDefaultEncoding()
+    {
+        if ( sourceEncoding == null )
+        {
+            getLog().warn(
+                    "Using platform encoding ("
+                            + Charset.defaultCharset()
+                            + " actually) to read Play listing text files, i.e. build is platform dependent!" );
         }
     }
 

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PublishApkMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PublishApkMojo.java
@@ -85,6 +85,8 @@ public class PublishApkMojo extends AbstractPublisherMojo
     private void publishWhatsNew( String packageName, AndroidPublisher.Edits edits, String editId, Apk apk )
             throws IOException
     {
+        warnPlatformDefaultEncoding();
+        
         File[] localeDirs = getLocaleDirs();
         if ( localeDirs == null )
         {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PublishListingMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/PublishListingMojo.java
@@ -6,6 +6,7 @@ import com.google.api.services.androidpublisher.AndroidPublisher;
 import com.google.api.services.androidpublisher.model.Listing;
 import com.jayway.maven.plugins.android.AbstractPublisherMojo;
 import com.jayway.maven.plugins.android.common.AndroidPublisherHelper;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -76,6 +77,7 @@ public class PublishListingMojo extends AbstractPublisherMojo
 
     private void publishListing() throws MojoExecutionException, MojoFailureException
     {
+        warnPlatformDefaultEncoding();
 
         File[] localeDirs = getLocaleDirs();
         if ( localeDirs == null )


### PR DESCRIPTION
Implements #601. I followed [this](http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding) guide to use the property. From my understanding, this property is not defined in the Maven model at all, since can be null. I do not think we can force users to define it, so i decided to use a default value (UTF-8). But i am open to any suggestions on this. Also i am wonder: should we make this read-only? In that case, users could not set it in the mojo config, only with the global property (however, in special situations they may want to use a different value for that).