### PR TITLE
Regex support for VersionGenerator

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/configuration/ManifestMerger.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/ManifestMerger.java
@@ -35,6 +35,12 @@ public class ManifestMerger
 
     /**
      * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
+     * #manifestVersionNamingPattern}.
+     */
+    protected String versionNamingPattern;
+
+    /**
+     * Mirror of {@link com.jayway.maven.plugins.android.standalonemojos.ManifestMergerMojo
      * #manifestVersionDigits}.
      */
     protected String versionDigits;
@@ -69,6 +75,11 @@ public class ManifestMerger
     public Boolean getVersionCodeUpdateFromVersion()
     {
         return versionCodeUpdateFromVersion;
+    }
+
+    public String getVersionNamingPattern()
+    {
+        return versionNamingPattern;
     }
 
     public String getVersionDigits()

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/RegexVersionElementParser.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/RegexVersionElementParser.java
@@ -1,0 +1,56 @@
+package com.jayway.maven.plugins.android.configuration;
+
+import static java.lang.String.format;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Regex-based VersionElementParser implementation.
+ *
+ * @author Wang Xuerui <idontknw.wang@gmail.com>
+ *
+ */
+public class RegexVersionElementParser implements VersionElementParser
+{
+
+    private Pattern namingPattern;
+
+    public RegexVersionElementParser( String pattern )
+    {
+        namingPattern = Pattern.compile( pattern );
+    }
+
+    @Override
+    public int[] parseVersionElements( final String versionName ) throws MojoExecutionException
+    {
+        final Matcher matcher = namingPattern.matcher( versionName );
+        if ( ! matcher.find() )
+        {
+            throw new MojoExecutionException( format(
+                    "The version naming pattern failed to match version name: %s against %s",
+                    namingPattern, versionName ) );
+        }
+
+        int elementCount = matcher.groupCount();
+        int[] result = new int[elementCount];
+
+        for ( int i = 0; i < elementCount; i++ )
+        {
+            // Capturing groups start at index 1
+            try
+            {
+                result[i] = Integer.valueOf( matcher.group( i + 1 ) );
+            }
+            catch ( NumberFormatException ignored )
+            {
+                // Either the group is not present, or cannot be cast to integer.
+                result[i] = 0;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/SimpleVersionElementParser.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/SimpleVersionElementParser.java
@@ -1,0 +1,27 @@
+package com.jayway.maven.plugins.android.configuration;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * VersionElementParser implementing the old version generator behavior.
+ *
+ * @author Wang Xuerui <idontknw.wang@gmail.com>
+ *
+ */
+public class SimpleVersionElementParser implements VersionElementParser
+{
+
+    @Override
+    public int[] parseVersionElements( final String versionName ) throws MojoExecutionException
+    {
+        final String[] versionNameElements = versionName.replaceAll( "[^0-9.]", "" ).split( "\\." );
+        int[] result = new int[versionNameElements.length];
+
+        for ( int i = 0; i < versionNameElements.length; i++ )
+        {
+            result[i] = Integer.valueOf( versionNameElements[i] );
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/VersionElementParser.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/VersionElementParser.java
@@ -1,0 +1,14 @@
+package com.jayway.maven.plugins.android.configuration;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Interface for parsing version names into version elements.
+ *
+ * @author Wang Xuerui <idontknw.wang@gmail.com>
+ *
+ */
+public interface VersionElementParser
+{
+    int[] parseVersionElements( final String versionName ) throws MojoExecutionException;
+}

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
@@ -20,16 +20,20 @@ public class VersionGenerator
 
     public VersionGenerator()
     {
-        this( "4,3,3" );
+        this( "4,3,3", "" );
     }
 
     public VersionGenerator( String versionDigits )
+    {
+        this( versionDigits, "" );
+    }
+
+    public VersionGenerator( String versionDigits, String versionNamingPattern )
     {
         final String[] digits = versionDigits.split( "[,;]" );
 
         this.elementsCount = digits.length;
         this.multipliers = new int[this.elementsCount];
-        this.elementParser = new SimpleVersionElementParser();
 
         int total = 0;
 
@@ -45,6 +49,17 @@ public class VersionGenerator
         if ( total < 1 || total > 10 )
         {
             throw new IllegalArgumentException( format( "Invalid number of digits, got %d", total ) );
+        }
+
+        // Choose a version element parser implementation based on the naming pattern
+        // passed in; an empty pattern triggers the old behavior.
+        if ( ! versionNamingPattern.isEmpty() )
+        {
+            this.elementParser = new RegexVersionElementParser( versionNamingPattern );
+        }
+        else
+        {
+            this.elementParser = new SimpleVersionElementParser();
         }
     }
 

--- a/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
+++ b/src/main/java/com/jayway/maven/plugins/android/configuration/VersionGenerator.java
@@ -7,6 +7,7 @@ import static java.lang.String.format;
 
 /**
  * @author Pappy STĂNESCU <a href="mailto:pappy.stanescu&#64;gmail.com">&lt;pappy.stanescu&#64;gmail.com&gt;</a>
+ * @author Wang Xuerui <idontknw.wang@gmail.com>
  */
 public class VersionGenerator
 {
@@ -14,6 +15,8 @@ public class VersionGenerator
     private final int elementsCount;
 
     private final int[] multipliers;
+
+    private final VersionElementParser elementParser;
 
     public VersionGenerator()
     {
@@ -26,6 +29,7 @@ public class VersionGenerator
 
         this.elementsCount = digits.length;
         this.multipliers = new int[this.elementsCount];
+        this.elementParser = new SimpleVersionElementParser();
 
         int total = 0;
 
@@ -46,7 +50,7 @@ public class VersionGenerator
 
     public int generate( String versionName ) throws MojoExecutionException
     {
-        final String[] versionNameElements = versionName.replaceAll( "[^0-9.]", "" ).split( "\\." );
+        final int[] versionElements = elementParser.parseVersionElements( versionName );
 
         long versionCode = 0;
 
@@ -54,10 +58,9 @@ public class VersionGenerator
         {
             versionCode *= this.multipliers[k];
 
-            if ( k < versionNameElements.length )
+            if ( k < versionElements.length )
             {
-                final String versionElement = versionNameElements[k];
-                final int elementValue = Integer.valueOf( versionElement );
+                final int elementValue = versionElements[k];
 
                 if ( elementValue >= this.multipliers[k] )
                 {

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -61,6 +61,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
      *             &lt;versionName&gt;&lt;/versionName&gt;
      *             &lt;versionCode&gt;123&lt;/versionCode&gt;
      *             &lt;versionCodeUpdateFromVersion&gt;true|false&lt;/versionCodeUpdateFromVersion&gt;
+     *             &lt;versionNamingPattern&gt;&lt;/versionNamingPattern&gt;
      *             &lt;mergeLibraries&gt;true|false&lt;/mergeLibraries&gt;
      *             &lt;mergeReportFile&gt;${project.build.directory}/ManifestMergeReport.txt&lt;/mergeReportFile&gt;
      *             &lt;usesSdk&gt;
@@ -118,7 +119,8 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
      * set the pattern to a non-empty string to activate. Otherwise, continue using the old
      * behavior of separating version elements by dots and ignoring all non-digit characters.
      * The pattern is standard Java regex. Capturing groups in the pattern are sequentially passed
-     * to the version code generator, while other parts are ignored.
+     * to the version code generator, while other parts are ignored. Be sure to properly escape
+     * your pattern string, in case you use characters that have special meaning in XML.
      * Exposed via the project property
      * <code>android.manifestMerger.versionNamingPattern</code>.
      */

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -113,6 +113,19 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
     protected Boolean manifestVersionCodeUpdateFromVersion = false;
 
     /**
+     * Optionally use a pattern to match version elements for automatic generation of version codes,
+     * useful in case of complex version naming schemes. The new behavior is disabled by default;
+     * set the pattern to a non-empty string to activate. Otherwise, continue using the old
+     * behavior of separating version elements by dots and ignoring all non-digit characters.
+     * The pattern is standard Java regex. Capturing groups in the pattern are sequentially passed
+     * to the version code generator, while other parts are ignored.
+     * Exposed via the project property
+     * <code>android.manifestMerger.versionNamingPattern</code>.
+     */
+    @Parameter( property = "android.manifestMerger.versionNamingPattern", defaultValue = "" )
+    protected String manifestVersionNamingPattern;
+
+    /**
      * The number of digits per version element. Must be specified as a comma/semicolon separated list of
      * digits, one for each version element, Exposed via the project property
      * <code>android.manifestMerger.versionDigits</code>.
@@ -140,6 +153,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
      */
     protected UsesSdk manifestUsesSdk;
     private Boolean parsedVersionCodeUpdateFromVersion;
+    private String parsedVersionNamingPattern;
     private String parsedVersionDigits;
     private Boolean parsedMergeLibraries;
     private String parsedVersionName;
@@ -172,6 +186,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
         getLog().debug( "    versionCode=" + parsedVersionCode );
         getLog().debug( "    usesSdk=" + parsedUsesSdk );
         getLog().debug( "    versionCodeUpdateFromVersion=" + parsedVersionCodeUpdateFromVersion );
+        getLog().debug( "    versionNamingPattern=" + parsedVersionNamingPattern );
         getLog().debug( "    versionDigits=" + parsedVersionDigits );
         getLog().debug( "    mergeLibraries=" + parsedMergeLibraries );
         getLog().debug( "    mergeReportFile=" + parsedMergeReportFile );
@@ -214,6 +229,14 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
             {
                 parsedVersionCodeUpdateFromVersion = manifestVersionCodeUpdateFromVersion;
             }
+            if ( manifestMerger.getVersionNamingPattern() != null )
+            {
+                parsedVersionNamingPattern = manifestMerger.getVersionNamingPattern();
+            }
+            else
+            {
+                parsedVersionNamingPattern = manifestVersionNamingPattern;
+            }
             if ( manifestMerger.getVersionDigits() != null )
             {
                 parsedVersionDigits = manifestMerger.getVersionDigits();
@@ -253,6 +276,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
             parsedVersionCode = manifestVersionCode;
             parsedUsesSdk = manifestUsesSdk;
             parsedVersionCodeUpdateFromVersion = manifestVersionCodeUpdateFromVersion;
+            parsedVersionNamingPattern = manifestVersionNamingPattern;
             parsedVersionDigits = manifestVersionDigits;
             parsedMergeLibraries = manifestMergeLibraries;
             parsedMergeReportFile = manifestMergeReportFile;
@@ -276,7 +300,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
         if ( parsedVersionCodeUpdateFromVersion )
         {
             VersionGenerator gen = new VersionGenerator( parsedVersionDigits );
-            
+
             versionCode = gen.generate( parsedVersionName );
         }
         else

--- a/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -299,7 +299,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
         }
         if ( parsedVersionCodeUpdateFromVersion )
         {
-            VersionGenerator gen = new VersionGenerator( parsedVersionDigits );
+            VersionGenerator gen = new VersionGenerator( parsedVersionDigits, parsedVersionNamingPattern );
 
             versionCode = gen.generate( parsedVersionName );
         }

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/RegexVersionElementParserTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/RegexVersionElementParserTest.java
@@ -1,0 +1,57 @@
+package com.jayway.maven.plugins.android.configuration;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+/**
+ * @author Wang Xuerui <idontknw.wang@gmail.com>
+ */
+public class RegexVersionElementParserTest
+{
+
+    @Test
+    public void prefixMatch() throws MojoExecutionException
+    {
+        assertArrayEquals( new int[] { 4, 1, 16, 8 }, new RegexVersionElementParser( "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)" ).parseVersionElements( "4.1.16.8-SNAPSHOT.1946" ) );
+        assertArrayEquals( new int[] { 0, 0, 38 }, new RegexVersionElementParser( "^(\\d+)\\.(\\d+)-(\\d+)" ).parseVersionElements( "0.0-38-g493f883" ) );
+        assertArrayEquals( new int[] { 5, 0, 1 }, new RegexVersionElementParser( "^(\\d+)\\.(\\d+)\\.(\\d+)" ).parseVersionElements( "5.0.1 (1642443)" ) );
+        assertArrayEquals( new int[] { 6, 1, 0, 66 }, new RegexVersionElementParser( "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)" ).parseVersionElements( "6.1.0.66-r1062275" ) );
+    }
+
+    @Test
+    public void fullMatch() throws MojoExecutionException
+    {
+        assertArrayEquals( new int[] { 5, 0, 1, 1642443 }, new RegexVersionElementParser( "^(\\d+)\\.(\\d+)\\.(\\d+) \\((\\d+)\\)$" ).parseVersionElements( "5.0.1 (1642443)" ) );
+        assertArrayEquals( new int[] { 6, 1, 0, 66, 1062275 }, new RegexVersionElementParser( "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)-r(\\d+)$" ).parseVersionElements( "6.1.0.66-r1062275" ) );
+    }
+
+    @Test
+    public void variableLengthResult() throws MojoExecutionException
+    {
+        final String pattern1 = "^(\\d+)\\.(\\d+)(?:-(\\d+)-g[0-9a-f]+(?:-dirty)?)?$";
+        assertArrayEquals( new int[] { 0, 0, 38 }, new RegexVersionElementParser( pattern1 ).parseVersionElements( "0.0-38-g493f883" ) );
+        assertArrayEquals( new int[] { 0, 0, 38 }, new RegexVersionElementParser( pattern1 ).parseVersionElements( "0.0-38-g493f883-dirty" ) );
+        assertArrayEquals( new int[] { 1, 0, 0 }, new RegexVersionElementParser( pattern1 ).parseVersionElements( "1.0" ) );
+
+        final String pattern2 = "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)(?:-[A-Z]+\\.(\\d+))?$";
+        assertArrayEquals( new int[] { 4, 1, 16, 8, 1946 }, new RegexVersionElementParser( pattern2 ).parseVersionElements( "4.1.16.8-SNAPSHOT.1946" ) );
+        assertArrayEquals( new int[] { 4, 1, 16, 8, 0 }, new RegexVersionElementParser( pattern2 ).parseVersionElements( "4.1.16.8" ) );
+    }
+
+    @Test
+    public void failedMatch() throws MojoExecutionException
+    {
+        try
+        {
+            new RegexVersionElementParser( "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)" ).parseVersionElements( "4.1.16-SNAPSHOT.1946" );
+            fail( "Expecting MojoExecutionException" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            System.err.println( "OK: " + e );
+        }
+    }
+}

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/SimpleVersionElementParserTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/SimpleVersionElementParserTest.java
@@ -1,0 +1,29 @@
+package com.jayway.maven.plugins.android.configuration;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+/**
+ * @author Wang Xuerui <idontknw.wang@gmail.com>
+ */
+public class SimpleVersionElementParserTest
+{
+
+    @Test
+    public void simple() throws MojoExecutionException
+    {
+        assertArrayEquals( new int[] { 2, 14, 748, 3647 }, new SimpleVersionElementParser().parseVersionElements( "2.14.748.3647" ) );
+        assertArrayEquals( new int[] { 2147, 483, 64, 7 }, new SimpleVersionElementParser().parseVersionElements( "2147.483.64.7" ) );
+        assertArrayEquals( new int[] { 2, 1, 4, 7, 4, 8, 3, 6, 4, 7 }, new SimpleVersionElementParser().parseVersionElements( "2.1.4.7.4.8.3.6.4.7" ) );
+    }
+
+    @Test
+    public void mixed() throws MojoExecutionException
+    {
+        assertArrayEquals( new int[] { 4, 1, 16, 8, 1946 }, new SimpleVersionElementParser().parseVersionElements( "4.1.16.8-SNAPSHOT.1946" ) );
+        assertArrayEquals( new int[] { 1, 2, 15, 8, 1946 }, new SimpleVersionElementParser().parseVersionElements( "1.2.15.8-SNAPSHOT.1946" ) );
+        assertArrayEquals( new int[] { 2, 1, 6, 1246 }, new SimpleVersionElementParser().parseVersionElements( "2.1.6-SNAPSHOT.1246" ) );
+    }
+}

--- a/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
+++ b/src/test/java/com/jayway/maven/plugins/android/configuration/VersionGeneratorTest.java
@@ -26,9 +26,16 @@ public class VersionGeneratorTest
     }
 
     @Test
+    public void generateRegex() throws MojoExecutionException
+    {
+        assertEquals( 2147483647, new VersionGenerator( "1,2,3,4", "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$" ).generate( "2.14.748.3647" ) );
+        assertEquals( 2147483647, new VersionGenerator( "4,3,2,1", "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$" ).generate( "2147.483.64.7" ) );
+    }
+
+    @Test
     public void compare() throws MojoExecutionException {
         VersionGenerator gen = new VersionGenerator( "3,3,3" );
-    
+
         assertTrue( gen.generate( "1.0" ) < gen.generate( "1.0.1" ) );
         assertTrue( gen.generate( "2.0" ) > gen.generate( "1.0.1" ) );
    }
@@ -37,10 +44,10 @@ public class VersionGeneratorTest
     public void realCase() throws MojoExecutionException
     {
         VersionGenerator gen = new VersionGenerator( "1,1,2,1,4" );
-        
+
         int v1 = gen.generate( "4.1.16.8-SNAPSHOT.1946" );
         int v2 = gen.generate( "4.1.17.8-SNAPSHOT.1246" );
-        
+
         assertEquals(411681946, v1 );
         assertEquals(411781246, v2 );
 
@@ -49,14 +56,54 @@ public class VersionGeneratorTest
     }
 
     @Test
+    public void realCaseRegex() throws MojoExecutionException
+    {
+        {
+            VersionGenerator gen = new VersionGenerator( "1,1,2,1,4", "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)(?:-[A-Z]+\\.(\\d+))?$" );
+
+            int v1 = gen.generate( "4.1.16.8-SNAPSHOT.1946" );
+            int v2 = gen.generate( "4.1.17.8" );
+
+            assertEquals( 411681946, v1 );
+            assertEquals( 411780000, v2 );
+
+            assertTrue( v1 < v2 );
+        }
+
+        {
+            VersionGenerator gen = new VersionGenerator( "4,3,3", "^(\\d+)\\.(\\d+)(?:-(\\d+)-g[0-9a-f]+(?:-dirty)?)?$" );
+
+            int v1 = gen.generate( "0.0-38-g493f883" );
+            int v2 = gen.generate( "0.1" );
+
+            assertEquals( 38, v1 );
+            assertEquals( 1000, v2 );
+
+            assertTrue( v1 < v2 );
+        }
+
+        {
+            VersionGenerator gen = new VersionGenerator( "3,2,2,3", "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)" );
+
+            int v1 = gen.generate( "6.1.0.66-r1062275" );
+            int v2 = gen.generate( "6.2.0.0-r1234567" );
+
+            assertEquals( 60100066, v1 );
+            assertEquals( 60200000, v2 );
+
+            assertTrue( v1 < v2 );
+        }
+    }
+
+    @Test
     public void mixedCase() throws MojoExecutionException
     {
         VersionGenerator g1 = new VersionGenerator( "1,1,2,1,4" );
         VersionGenerator g2 = new VersionGenerator( "1,1,2,5" );
-        
+
         int v1 = g1.generate( "1.2.15.8-SNAPSHOT.1946" );
         int v2 = g2.generate( "2.1.6-SNAPSHOT.1246" );
-        
+
         assertEquals(121581946, v1 );
         assertEquals(210601246, v2 );
 


### PR DESCRIPTION
This fixes #605, complete with test cases. Hopefully I didn't miss anything important (the XML part is automatically done by the mojo, right?); please review.

Thanks!