### PR TITLE
Implemented using aar consumer proguard configurations in ProguardMojo

### DIFF
--- a/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -391,6 +391,19 @@ public class ProguardMojo extends AbstractAndroidMojo
             proguardCommands.add( "@" + proguardFile.getAbsolutePath() );
         }
 
+        for ( Artifact artifact : getDirectDependencyArtifacts() )
+        {
+            if ( AAR.equals( artifact.getType() ) )
+            {
+                File unpackedLibFolder = getUnpackedLibFolder( artifact );
+                File proguardFile = new File( unpackedLibFolder, "proguard.txt" );
+                if ( proguardFile.exists() )
+                {
+                    proguardCommands.add( "@" + proguardFile.getAbsolutePath() );
+                }
+            }
+        }
+
         collectInputFiles( proguardCommands );
 
         proguardCommands.add( "-outjars" );
@@ -429,7 +442,7 @@ public class ProguardMojo extends AbstractAndroidMojo
             IOUtils.write( commandStringBuilder, tempConfigFileOutputStream );
 
             executor.setCaptureStdOut( true );
-            commands.add( "@\"" + tempConfigFile.getAbsolutePath() + "\"" );
+            commands.add( "@" + tempConfigFile.getAbsolutePath() + "" );
             executor.executeCommand( javaExecutable, commands, project.getBasedir(), false );
         }
         catch ( ExecutionException e )


### PR DESCRIPTION
Gradle has a feature, where you can specify consumerProguardFiles to include
a proguard configuration into an aar artifact.
See https://plus.google.com/+IanLake/posts/1HfDuFFkMXG for more info about
consumerProguardFiles.

This pr only covers using the included proguard files. Including a proguard configuration into aars generated by maven is still open. 

refs #611