### PR TITLE
Fixed a NullPointerException if versionNamingPattern is not defined

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/configuration/VersionGenerator.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/configuration/VersionGenerator.java
@@ -53,7 +53,7 @@ public class VersionGenerator
 
         // Choose a version element parser implementation based on the naming pattern
         // passed in; an empty pattern triggers the old behavior.
-        if ( ! versionNamingPattern.isEmpty() )
+        if ( versionNamingPattern != null && ! versionNamingPattern.isEmpty() )
         {
             this.elementParser = new RegexVersionElementParser( versionNamingPattern );
         }

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -129,7 +129,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
      * Exposed via the project property
      * <code>android.manifestMerger.versionNamingPattern</code>.
      */
-    @Parameter( property = "android.manifestMerger.versionNamingPattern", defaultValue = "" )
+    @Parameter( property = "android.manifestMerger.versionNamingPattern" )
     protected String manifestVersionNamingPattern;
 
     /**


### PR DESCRIPTION
Hello everyone,

It seems as one major use case was overlooked while working on #605 and #606. What happens if Maven descriptor maintainer DOES NOT include or declare the *versionNamingPattern* property? Or leaves it blank. Judging by the way Maven behaves, the propery would evaluate to *null*, and cause a NullPointerException when accessing the value in *VersionGenetator* class constructor. Setting *Parameter* annotation *defaultValue* to empty parenthesis does not help much.

Hence there are two options. Either something is totally wrong with Maven 3.2.1 I am using (which could be the case after all), or the fix proposed here solves the issue at hand, without breaking anything.