### PR TITLE
WIP Update Android Builder to 1.3.0-beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
     <!-- Attention - make sure that the tools version is the versions of 
       the transitive dependencies of the builder version -->
-    <android.builder.version>1.2.2</android.builder.version>
-    <android.tools.version>24.2.2</android.tools.version>
+    <android.builder.version>1.3.0-beta1</android.builder.version>
+    <android.tools.version>24.3.0-beta1</android.tools.version>
   </properties>
 
   <scm>
@@ -113,6 +113,16 @@
     <!-- define the version need to run this plugin -->
     <maven>3.0.4</maven>
   </prerequisites>
+  
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jcenter</id>
+      <url>http://jcenter.bintray.com</url>
+    </repository>
+  </repositories>
 
   <dependencyManagement>
     <dependencies>
@@ -159,6 +169,12 @@
       <dependency>
         <groupId>com.android.tools.build</groupId>
         <artifactId>builder</artifactId>
+        <version>${android.builder.version}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>com.android.tools.build</groupId>
+        <artifactId>builder-model</artifactId>
         <version>${android.builder.version}</version>
       </dependency>
 
@@ -365,6 +381,11 @@
     <dependency>
       <groupId>com.android.tools.build</groupId>
       <artifactId>builder</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.android.tools.build</groupId>
+      <artifactId>builder-model</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -2,6 +2,9 @@ package com.simpligility.maven.plugins.android.standalonemojos;
 
 import com.android.SdkConstants;
 import com.android.builder.core.AndroidBuilder;
+import com.android.builder.core.EvaluationErrorReporter;
+import com.android.builder.core.EvaluationErrorReporter.EvaluationMode;
+import com.android.builder.model.SyncIssue;
 import com.android.ide.common.process.DefaultProcessExecutor;
 import com.android.ide.common.process.LoggedProcessOutputHandler;
 import com.android.manifmerger.ManifestMerger2;
@@ -294,11 +297,21 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
     public void manifestMergerV2() throws MojoExecutionException, MojoFailureException
     {
         ILogger logger = new MavenILogger( getLog() );
+        
+        EvaluationErrorReporter reporter = new EvaluationErrorReporter( EvaluationMode.STANDARD )
+        {
+            @Override
+            public SyncIssue handleSyncError( String data, int type, String msg )
+            {
+                return null;
+            }
+        };
+        
         AndroidBuilder builder = new AndroidBuilder( project.toString(), "created by Android Maven Plugin",
                 new DefaultProcessExecutor( logger ),
                 new DefaultJavaProcessExecutor( logger ),
                 new LoggedProcessOutputHandler( logger ),
-                logger, false );
+                reporter, logger, false );
 
         String minSdkVersion = null;
         String targetSdkVersion = null;


### PR DESCRIPTION
This is a throw-in fix for #635. It is not ready for merge yet, because new dependencies are only available from jcenter. Also the Android tool dependencies are updated to a beta version.