### PR TITLE
Feature choose which version of the build tools to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ before_install:
   # removed > /dev/null to prevent Travis timing out and ease debugging
   - echo y | android update sdk --filter tools,platform-tools --no-ui --force --all
   - echo y | android update sdk --filter build-tools-19.0.3 --no-ui --force --all
+  - echo y | android update sdk --filter build-tools-21.1.2 --no-ui --force --all
+  - echo y | android update sdk --filter build-tools-22.0.0 --no-ui --force --all
+  - echo y | android update sdk --filter build-tools-22.0.1 --no-ui --force --all
   - echo y | android update sdk --filter $ANDROID_TARGET --no-ui --force --all
   - echo y | android update sdk --filter sys-img-$ANDROID_ABI-$ANDROID_TARGET --no-ui --force --all
   - echo y | android update sdk --filter extra-android-support,extra-android-m2repository --no-ui --force --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - echo y | android update sdk --filter tools,platform-tools --no-ui --force --all
   - echo y | android update sdk --filter build-tools-19.0.3 --no-ui --force --all
   - echo y | android update sdk --filter build-tools-21.1.2 --no-ui --force --all
-  - echo y | android update sdk --filter build-tools-22.0.0 --no-ui --force --all
   - echo y | android update sdk --filter build-tools-22.0.1 --no-ui --force --all
   - echo y | android update sdk --filter $ANDROID_TARGET --no-ui --force --all
   - echo y | android update sdk --filter sys-img-$ANDROID_ABI-$ANDROID_TARGET --no-ui --force --all

--- a/src/main/java/com/simpligility/maven/plugins/android/AbstractAndroidMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AbstractAndroidMojo.java
@@ -1107,10 +1107,12 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
     {
         File chosenSdkPath;
         String chosenSdkPlatform;
+        String buildToolsVersion = null;
 
         if ( sdk != null )
         {
             // An <sdk> tag exists in the pom.
+            buildToolsVersion = sdk.getBuildTools();
 
             if ( sdk.getPath() != null )
             {
@@ -1164,7 +1166,7 @@ public abstract class AbstractAndroidMojo extends AbstractMojo
             chosenSdkPlatform = sdkPlatform;
         }
 
-        return new AndroidSdk( chosenSdkPath, chosenSdkPlatform );
+        return new AndroidSdk( chosenSdkPath, chosenSdkPlatform, buildToolsVersion );
     }
 
     private String getAndroidHomeOrThrow() throws MojoExecutionException

--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
@@ -16,11 +16,13 @@
 package com.simpligility.maven.plugins.android;
 
 import com.android.SdkConstants;
+import com.android.annotations.Nullable;
 import com.android.sdklib.AndroidTargetHash;
 import com.android.sdklib.AndroidVersion;
 import com.android.sdklib.BuildToolInfo;
 import com.android.sdklib.IAndroidTarget;
 import com.android.sdklib.SdkManager;
+import com.android.sdklib.repository.FullRevision;
 import com.android.utils.NullLogger;
 import org.apache.maven.plugin.MojoExecutionException;
 
@@ -42,7 +44,7 @@ public class AndroidSdk
      * the default API level for the SDK used as a fall back if none is supplied, 
      * should ideally point to the latest available version
      */
-    private static final String DEFAULT_ANDROID_API_LEVEL = "19";
+    private static final String DEFAULT_ANDROID_API_LEVEL = "22";
     /**
      * property file in each platform folder with details about platform.
      */
@@ -69,10 +71,17 @@ public class AndroidSdk
     private final IAndroidTarget androidTarget;
     private SdkManager sdkManager;
     private int sdkMajorVersion;
+    private String buildToolsVersion;
 
     public AndroidSdk( File sdkPath, String apiLevel )
     {
+        this( sdkPath, apiLevel, null );
+    }
+
+    public AndroidSdk( File sdkPath, String apiLevel, @Nullable String buildToolsVersion )
+    {
         this.sdkPath = sdkPath;
+        this.buildToolsVersion = buildToolsVersion;
 
         if ( sdkPath != null )
         {
@@ -253,12 +262,17 @@ public class AndroidSdk
     
     private BuildToolInfo getBuildToolInfo()
     {
+        if ( buildToolsVersion != null && !buildToolsVersion.equals( "" ) )
+        {
+            return sdkManager.getBuildTool( FullRevision.parseRevision( buildToolsVersion ) );
+        }
+
         if ( androidTarget != null )
         {
             BuildToolInfo buildToolInfo = androidTarget.getBuildToolInfo();
             if ( buildToolInfo != null ) 
             {
-                return androidTarget.getBuildToolInfo();
+                return buildToolInfo;
             }
         }
         // if no valid target is defined, or it has no build tools installed, try to use the latest

--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
@@ -262,9 +262,18 @@ public class AndroidSdk
     
     private BuildToolInfo getBuildToolInfo()
     {
+        //First we use the build tools specified in the pom file
         if ( buildToolsVersion != null && !buildToolsVersion.equals( "" ) )
         {
-            return sdkManager.getBuildTool( FullRevision.parseRevision( buildToolsVersion ) );
+            BuildToolInfo buildToolInfo = sdkManager.getBuildTool( FullRevision.parseRevision( buildToolsVersion ) );
+            if ( buildToolInfo != null )
+            {
+                return buildToolInfo;
+            }
+            //Since we cannot find the build tool specified by the user we make it fail
+            // instead of using the latest build tool version
+            throw new InvalidSdkException( "Invalid SDK: Build-tools " + buildToolsVersion + " not found."
+                    + " Check your Android SDK to install the build tools " + buildToolsVersion );
         }
 
         if ( androidTarget != null )

--- a/src/main/java/com/simpligility/maven/plugins/android/configuration/Sdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/configuration/Sdk.java
@@ -43,6 +43,13 @@ public class Sdk
     @Parameter ( property = "android.sdk.platform" )
     private String platform;
 
+    /**
+     * <p>Chosen Build-Tools version. Valid values are whichever build-tools are available in the SDK,
+     * under the directory <code>buildTools</code>. Defaults to the latest available one if not set.</p>
+     */
+    @Parameter ( property = "android.sdk.buildTools" )
+    private String buildTools;
+
     public File getPath()
     {
         return path;
@@ -51,5 +58,10 @@ public class Sdk
     public String getPlatform()
     {
         return platform;
+    }
+
+    public String getBuildTools()
+    {
+        return buildTools;
     }
 }

--- a/src/site/asciidoc/changelog.adoc
+++ b/src/site/asciidoc/changelog.adoc
@@ -5,6 +5,9 @@
 * Fixed processing of duplicate resources from dependencies
 ** see https://github.com/simpligility/android-maven-plugin/pull/614
 ** contributed by Marek Kedzierski https://github.com/kedzie
+* Ability to choose the build tools version
+** see https://github.com/simpligility/android-maven-plugin/pull/637
+** Contributed by Benoit Billington https://github.com/Shusshu
 
 Planned changes:
 

--- a/src/test/java/com/simpligility/maven/plugins/android/AndroidSdkTest.java
+++ b/src/test/java/com/simpligility/maven/plugins/android/AndroidSdkTest.java
@@ -76,16 +76,62 @@ public class AndroidSdkTest {
      * for this test to pass including the obsolete ones.
      */
     @Test
-    public void validPlatformsAndApiLevels() {
+    public void validPlatformsAndApiLevels1() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
         final AndroidSdk sdk19 = new AndroidSdk(new File(sdkTestSupport.getEnv_ANDROID_HOME()), "19"); 
     }
 
-    @Test(expected = InvalidSdkException.class)
-    public void invalidPlatformAndApiLevels() {
-        final AndroidSdk invalid = new AndroidSdk(new File(sdkTestSupport.getEnv_ANDROID_HOME()), "invalid");
-
+    @Test
+    public void validPlatformsAndApiLevels2() {
+        // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
+        final AndroidSdk sdk21 = new AndroidSdk(new File(sdkTestSupport.getEnv_ANDROID_HOME()), "21", null);
+        Assert.assertTrue( sdk21.getAaptPath() != null && !sdk21.getAaptPath().equals( "" ) );
     }
 
+    @Test
+    public void validPlatformsAndApiLevels3() {
+        // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
+        final AndroidSdk sdk22 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME()), "22", "22.0.0" );
+        Assert.assertTrue( sdk22.getAaptPath() != null && !sdk22.getAaptPath().equals( "" ) );
+    }
+
+    @Test
+    public void validPlatformsAndApiLevels4() {
+        // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
+        final AndroidSdk sdk19 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "22", "22.0.0" );
+        Assert.assertTrue( sdk19.getAaptPath() != null && !sdk19.getAaptPath().equals( "" ) );
+    }
+
+    @Test(expected = InvalidSdkException.class)
+    public void invalidPlatformAndApiLevels() {
+        final AndroidSdk invalid = new AndroidSdk (new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "invalid" );
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void invalidBuildTools() {
+        final AndroidSdk invalid = new AndroidSdk (new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "invalid" );
+        invalid.getAaptPath();
+    }
+
+    @Test
+    public void validPlatformsAndApiLevelsWithDiffBuildTools1() {
+        // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "22" );
+        Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
+    }
+
+    @Test
+    public void validPlatformsAndApiLevelsWithDiffBuildTools2() {
+        // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "22.0.0" );
+        Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
+    }
+
+    @Test
+    public void validPlatformsAndApiLevelsWithDiffBuildToolsMinor() {
+        // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "21.1.2" );
+        Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
+    }
 
 }

--- a/src/test/java/com/simpligility/maven/plugins/android/AndroidSdkTest.java
+++ b/src/test/java/com/simpligility/maven/plugins/android/AndroidSdkTest.java
@@ -91,14 +91,14 @@ public class AndroidSdkTest {
     @Test
     public void validPlatformsAndApiLevels3() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk22 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME()), "22", "22.0.0" );
+        final AndroidSdk sdk22 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME()), "22", "22.0.1" );
         Assert.assertTrue( sdk22.getAaptPath() != null && !sdk22.getAaptPath().equals( "" ) );
     }
 
     @Test
     public void validPlatformsAndApiLevels4() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk19 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "22", "22.0.0" );
+        final AndroidSdk sdk19 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "22", "22.0.1" );
         Assert.assertTrue( sdk19.getAaptPath() != null && !sdk19.getAaptPath().equals( "" ) );
     }
 
@@ -123,7 +123,7 @@ public class AndroidSdkTest {
     @Test
     public void validPlatformsAndApiLevelsWithDiffBuildTools2() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "22.0.0" );
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "22.0.1" );
         Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
     }
 


### PR DESCRIPTION
This PR adds the ability to choose which the version of the build tools we want to use.

    <sdk>
         <platform>22</platform>
    <!--        <buildTools>19.0.0</buildTools> -->
    </sdk>

A) When a user does not set the build tools it will behaves exactly as it is now.


B) If the user decide to put a build tool it will try to find that version of the build tools or throw an exception.
I prefer this approach over the one where if it cannot find the build tools specified it will take the latest one... I assume if I user set that value there must be a reason and we don't want to use another build tool version. (With a CI you can be sure your PC and the CI uses the same build tools)


Note about the code:
When we receive an AndroidTarget for version 19 from the google lib it gives us the correct target but the target will always try to find the latest build tools.
So I decided to put a seperate parameter for the build tools (same as gradle btw) 