### PR TITLE
Also check directory called "android-arm" for gdb server

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidNdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidNdk.java
@@ -262,6 +262,7 @@ public class AndroidNdk
         List<String> gdbServerLocations = new ArrayList<String>();
         if ( ndkArchitecture.startsWith( "armeabi" ) )
         {
+            gdbServerLocations.add( "android-arm" );
             gdbServerLocations.add( "android-armeabi" );
             gdbServerLocations.addAll( Arrays.asList( ARM_TOOLCHAIN ) );
         }

--- a/src/site/asciidoc/changelog.adoc
+++ b/src/site/asciidoc/changelog.adoc
@@ -5,6 +5,9 @@
 * Make manifest merging less verbose
 ** See https://github.com/simpligility/android-maven-plugin/pull/650
 ** contributed by Nathan Toone https://github.com/Toonetown
+* Fix for gdbserver on NDK version r10e
+** See https://github.com/simpligility/android-maven-plugin/pull/648
+** contributed by Nathan Toone https://github.com/Toonetown
 * Fix building with debug mode and raw file directories
 ** See https://github.com/simpligility/android-maven-plugin/pull/649
 ** contributed by Nathan Toone https://github.com/Toonetown


### PR DESCRIPTION
At least on NDK version r10e, the GDB server for armeabi is now located in `<NDK_ROOT>/prebuilt/android-arm/gdbserver`.