### PR TITLE
Add extra arguments at (or near) the end of aapt command

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -876,14 +876,14 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 .addRawAssetsDirectoryIfExists( combinedAssets )
                 .addExistingPackageToBaseIncludeSet( getAndroidSdk().getAndroidJar() )
                 .addConfigurations( configurations )
-                .addExtraArguments( aaptExtraArgs )
                 .setVerbose( aaptVerbose )
                     // We need to generate R.txt for all projects as it needs to be consumed when generating R class.
                     // It also needs to be consumed when packaging aar.
                 .generateRTextFile( targetDirectory )
                 // If a proguard file is defined then output Proguard options to it.
                 .setProguardOptionsOutputFile( proguardFile )
-                .makeResourcesNonConstant( AAR.equals( project.getArtifact().getType() ) );
+                .makeResourcesNonConstant( AAR.equals( project.getArtifact().getType() ) )
+                .addExtraArguments( aaptExtraArgs );
 
         getLog().debug( getAndroidSdk().getAaptPath() + " " + commandBuilder.toString() );
         try
@@ -1033,8 +1033,8 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 .addRawAssetsDirectoryIfExists( apklibCombAssets )
                 .addExistingPackageToBaseIncludeSet( getAndroidSdk().getAndroidJar() )
                 .addConfigurations( configurations )
-                .addExtraArguments( aaptExtraArgs )
                 .setVerbose( aaptVerbose )
+                .addExtraArguments( aaptExtraArgs )
                 // We need to generate R.txt for all projects as it needs to be consumed when generating R class.
                 // It also needs to be consumed when packaging aar.
                 .generateRTextFile( unpackDir );

--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
@@ -1067,9 +1067,9 @@ public class ApkMojo extends AbstractAndroidMojo
                 .addExistingPackageToBaseIncludeSet( androidJar )
                 .setOutputApkFile( outputFile )
                 .addConfigurations( configurations )
-                .addExtraArguments( aaptExtraArgs )
                 .setVerbose( aaptVerbose )
-                .setDebugMode( !release );
+                .setDebugMode( !release )
+                .addExtraArguments( aaptExtraArgs );
 
         getLog().debug( getAndroidSdk().getAaptPath() + " " + commandBuilder.toString() );
         try


### PR DESCRIPTION
If you want to add additional raw file directories to the apk, you can specify them in extra arguments - however, these should come last in the aapt command (with the exception of `--output-text-symbols` - which is used when generating the `R.txt` file.  This PR just moves the `addExtraArguments` call later in the command list.