### PR TITLE
Make manifest merging less verbose

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/MavenILogger.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/MavenILogger.java
@@ -13,10 +13,18 @@ import java.util.Formatter;
 public class MavenILogger implements ILogger
 {
     private final Log log;
+    private final boolean verboseInfo;
+
+    public MavenILogger( Log log, boolean verboseInfo )
+    {
+        this.log = log;
+        this.verboseInfo = verboseInfo;
+    }
 
     public MavenILogger( Log log )
     {
         this.log = log;
+        this.verboseInfo = false;
     }
 
     @Override
@@ -53,7 +61,15 @@ public class MavenILogger implements ILogger
     public void info( @NonNull String s, Object... objects )
     {
         final Formatter formatter = new Formatter();
-        log.info( formatter.format( s, objects ).out().toString() );
+        if ( verboseInfo )
+        {
+            log.debug( formatter.format( s, objects ).out().toString() );
+        }
+        else
+        {
+            log.info( formatter.format( s, objects ).out().toString() );
+        }
+        
     }
 
     @Override

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ManifestMergerMojo.java
@@ -293,7 +293,7 @@ public class ManifestMergerMojo extends AbstractAndroidMojo
 
     public void manifestMergerV2() throws MojoExecutionException, MojoFailureException
     {
-        ILogger logger = new MavenILogger( getLog() );
+        ILogger logger = new MavenILogger( getLog(), ( parsedMergeReportFile != null ) );
         AndroidBuilder builder = new AndroidBuilder( project.toString(), "created by Android Maven Plugin",
                 new DefaultProcessExecutor( logger ),
                 new DefaultJavaProcessExecutor( logger ),

--- a/src/site/asciidoc/changelog.adoc
+++ b/src/site/asciidoc/changelog.adoc
@@ -2,6 +2,9 @@
 
 == 4.3.1 or higher - upcoming 
 
+* Make manifest merging less verbose
+** See https://github.com/simpligility/android-maven-plugin/pull/650
+** contributed by Nathan Toone https://github.com/Toonetown
 * Fix building with debug mode and raw file directories
 ** See https://github.com/simpligility/android-maven-plugin/pull/649
 ** contributed by Nathan Toone https://github.com/Toonetown


### PR DESCRIPTION
Currently, when you do manifest merging, it writes out all entries as `info` entries.  When you are storing the report to a file (using the `mergeReportFile` configuration parameter), this is extra information that doesn't need to be output to the screen (because it's in the file).  This patch adds an option to MavenILogger to treat `info` calls as `verbose`, and then uses that flag whenever the `mergeReportFile` parameter is specified.