### PR TITLE
Fix duplicate file detection logic - Issue 660

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
@@ -825,7 +825,7 @@ public class ApkMojo extends AbstractAndroidMojo
                     //if not handled by transformer, add (once) to duplicates jar
                     if ( !resourceTransformed )
                     {
-                        if ( duplicatesAdded.contains( entry.getName() ) )
+                        if ( !duplicatesAdded.contains( entry.getName() ) )
                         {
                         	duplicatesAdded.add( entry.getName() );
                             duplicateZos.putNextEntry( entry );

--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
@@ -825,7 +825,7 @@ public class ApkMojo extends AbstractAndroidMojo
                     //if not handled by transformer, add (once) to duplicates jar
                     if ( !resourceTransformed )
                     {
-                        if ( !duplicatesAdded.add( entry.getName() ) )
+                        if ( duplicatesAdded.add( entry.getName() ) )
                         {
                             duplicateZos.putNextEntry( entry );
                             InputStream currIn = inZip.getInputStream( entry );

--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
@@ -825,8 +825,9 @@ public class ApkMojo extends AbstractAndroidMojo
                     //if not handled by transformer, add (once) to duplicates jar
                     if ( !resourceTransformed )
                     {
-                        if ( duplicatesAdded.add( entry.getName() ) )
+                        if ( duplicatesAdded.contains( entry.getName() ) )
                         {
+                        	duplicatesAdded.add( entry.getName() );
                             duplicateZos.putNextEntry( entry );
                             InputStream currIn = inZip.getInputStream( entry );
                             copyStreamWithoutClosing( currIn, duplicateZos );

--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/ApkMojo.java
@@ -827,7 +827,7 @@ public class ApkMojo extends AbstractAndroidMojo
                     {
                         if ( !duplicatesAdded.contains( entry.getName() ) )
                         {
-                        	duplicatesAdded.add( entry.getName() );
+                            duplicatesAdded.add( entry.getName() );
                             duplicateZos.putNextEntry( entry );
                             InputStream currIn = inZip.getInputStream( entry );
                             copyStreamWithoutClosing( currIn, duplicateZos );


### PR DESCRIPTION
The error is occurring in method removeDuplicatesFromJar at line 830 of class ApkMojo in package com.simpligility.maven.plugins.android.phase09package:

duplicateZos.putNextEntry( entry );

The error is genuine in that the ZipEntry "entry" is a duplicate. The previous line failed to correctly detect a duplicate because the logic is reversed:

!duplicatesAdded.add( entry.getName() )

API: HashSet.add() returns true if this set did not already contain the specified element.

This change corrects indicated statement at line 828 by removing the exclamation mark in front of "duplicatessAdded".

 1 file changed, 1 insertion(+), 1 deletion(-)