### PR TITLE
NDK: set APP_BUILD_SCRIPT for makefile parameter instead of -f

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidNdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidNdk.java
@@ -38,7 +38,7 @@ public class AndroidNdk
             + "alternative, you may add the parameter to commandline: -Dandroid.ndk.path=... or set environment "
             + "variable " + NdkBuildMojo.ENV_ANDROID_NDK_HOME + ".";
 
-    public static final String[] NDK_ARCHITECTURES = { "armeabi", "armeabi-v7a", "mips", "mips64", "x86", "x86_64" };
+    public static final String[] NDK_ARCHITECTURES = { "armeabi", "armeabi-v7a", "arm64-v8a", "mips", "mips64", "x86", "x86_64" };
 
     /**
      * Arm toolchain implementations.
@@ -122,7 +122,10 @@ public class AndroidNdk
         }
 
         String fileName = "";
-        if ( toolchain.startsWith( "arm" ) )
+        if( toolchain.startsWith( "arm64-v8a")) {
+            fileName = "aarch64-linux-android-strip" + extension;
+        }
+        else if ( toolchain.startsWith( "arm" ) )
         {
             fileName = "arm-linux-androideabi-strip" + extension;
         }

--- a/src/test/projects/native/native-code-nonstandard-structure/.gitignore
+++ b/src/test/projects/native/native-code-nonstandard-structure/.gitignore
@@ -1,0 +1,2 @@
+libs
+obj

--- a/src/test/projects/native/native-code-nonstandard-structure/AndroidManifest.xml
+++ b/src/test/projects/native/native-code-nonstandard-structure/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.acme.hellojni"
+          android:versionCode="1"
+          android:versionName="1.0">
+    <uses-sdk android:minSdkVersion="3" />
+</manifest>

--- a/src/test/projects/native/native-code-nonstandard-structure/pom.xml
+++ b/src/test/projects/native/native-code-nonstandard-structure/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                              http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.jayway.maven.plugins.android.generation2.samples</groupId>
+    <artifactId>native-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>native-code-nonstandard-structure</artifactId>
+    <!--
+    Packaging is defined as 'so' - this will indicate to the Maven Android
+    plugin that it is meant to compile the native code.  The resulting native
+    library is attached to the build
+    -->
+  <packaging>so</packaging>
+
+  <name>Android NDK - Native Sample Non-standard folder structure</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.simpligility.maven.plugins</groupId>
+
+        <artifactId>android-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ndkArchitectures>x86 armeabi</ndkArchitectures>
+          <makefile>src/Android.mk</makefile>
+          <applicationMakefile>src/Application.mk</applicationMakefile>
+            <attachHeaderFiles>false</attachHeaderFiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/test/projects/native/native-code-nonstandard-structure/src/Android.mk
+++ b/src/test/projects/native/native-code-nonstandard-structure/src/Android.mk
@@ -1,0 +1,22 @@
+# Copyright (C) 2009 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE    := native-code-nonstandard-structure
+LOCAL_SRC_FILES := hello-jni.c
+
+include $(BUILD_SHARED_LIBRARY)

--- a/src/test/projects/native/native-code-nonstandard-structure/src/Application.mk
+++ b/src/test/projects/native/native-code-nonstandard-structure/src/Application.mk
@@ -1,0 +1,1 @@
+APP_ABI := armeabi x86

--- a/src/test/projects/native/native-code-nonstandard-structure/src/hello-jni.c
+++ b/src/test/projects/native/native-code-nonstandard-structure/src/hello-jni.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <string.h>
+#include <jni.h>
+
+/* This is a trivial JNI example where we use a native method
+ * to return a new VM String. See the corresponding Java source
+ * file located at:
+ *
+ *   apps/samples/hello-jni/project/src/com/example/HelloJni/HelloJni.java
+ */
+jstring
+Java_com_acme_hellojni_HelloJni_stringFromJNI( JNIEnv* env,
+                                                  jobject thiz )
+{
+    return (*env)->NewStringUTF(env, "Hello from Native JNI!");
+}

--- a/src/test/projects/native/pom.xml
+++ b/src/test/projects/native/pom.xml
@@ -29,6 +29,7 @@
     <module>java-with-native-apklib-dependency</module>
 <!--     <module>mixed-java-native-with-apklib-dependency</module> -->
     <module>transient-apklib-with-native</module>
+    <module>native-code-nonstandard-structure</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
the ```makefile``` ndk goal parameter doesn't work.  It adds a ```-f <makefile>``` to the ```ndk-build``` commandline.  That works for normal ```make``` but for ```ndk-build``` it should be setting ```APP_BUILD_SCRIPT=<makefile>``` instead.  This is what this fix is doing.