### PR TITLE
Fixes for provided apk dependency for instrumentation tests

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/common/UnpackedLibHelper.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/common/UnpackedLibHelper.java
@@ -174,7 +174,7 @@ public final class UnpackedLibHelper
                 + "_"
                 + artifact.getArtifactId()
                 + "_"
-                + artifact.getVersion()
+                + artifact.getBaseVersion()
         );
     }
 

--- a/src/main/java/com/simpligility/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase_prebuild/ClasspathModifierLifecycleParticipant.java
@@ -291,6 +291,7 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
         try
         {
             final ZipOutputStream zipOutputStream = new ZipOutputStream( new FileOutputStream( classesJar ) );
+            zipOutputStream.putNextEntry( new ZipEntry( "dummy" ) );
             zipOutputStream.close();
             log.debug( "Created dummy " + classesJar.getName() + " exist=" + classesJar.exists() );
         }
@@ -321,7 +322,7 @@ public final class ClasspathModifierLifecycleParticipant extends AbstractMavenLi
         final Dependency dependency = new Dependency();
         dependency.setGroupId( artifact.getGroupId() );
         dependency.setArtifactId( artifactId );
-        dependency.setVersion( artifact.getVersion() );
+        dependency.setVersion( artifact.getBaseVersion() );
         dependency.setScope( Artifact.SCOPE_SYSTEM );
         dependency.setSystemPath( location.getAbsolutePath() );
         return dependency;


### PR DESCRIPTION
-add dummy ZipEntry to apk placeholder. to avoid "0 entries" exception.  
-Changed system dependency to use BaseVersion for snapshot versions.

I had issue where the ClasspathModifierLifecycleParticipent used the
full snapshot version with timestamp for the placeholder and system dependency.
But the GenerateSourcesMojo used the SNAPSHOT version without timestamp, resulting in compilation errors.  Because actual apk classes.jar wasn't getting added to the classpath.

Note:  I experience these problems specifically when there wasn't any artifacts in the local repo.  I was doing a verify on an aggregator project, which had both the apk and test projects as modules.  So the apk had to come from the previous build, instead of the maven repo.  I think this had something to do with the problem.  I verified that now it consistently works.