### PR TITLE
Emma coverage was not applied to apklib or aar projects.  Now it is

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -58,7 +58,8 @@
           <generate-sources>com.simpligility.maven.plugins:android-maven-plugin:generate-sources</generate-sources>
           <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
           <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
-          <process-classes>com.simpligility.maven.plugins:android-maven-plugin:proguard</process-classes>
+          <process-classes>com.simpligility.maven.plugins:android-maven-plugin:emma,
+              com.simpligility.maven.plugins:android-maven-plugin:proguard</process-classes>
           <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
           <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
           <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
@@ -82,7 +83,8 @@
               <generate-sources>com.simpligility.maven.plugins:android-maven-plugin:generate-sources</generate-sources>
               <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
               <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
-              <process-classes>com.simpligility.maven.plugins:android-maven-plugin:proguard</process-classes>
+              <process-classes>com.simpligility.maven.plugins:android-maven-plugin:emma,
+                  com.simpligility.maven.plugins:android-maven-plugin:proguard</process-classes>
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
               <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>


### PR DESCRIPTION
When I followed the instructions at : http://simpligility.github.io/android-maven-plugin/emma.html I noticed that my coverage.em file was not being generated in my library module but it was in my test module.  I did some sleuthing and noticed the emma mojo wan't included for the aar packaging type.  I've updated this in the components file and have code coverage for my projects.