### PR TITLE
Fix connect and disconnect to not throw NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.0.15</version>
+        <version>3.0.21</version>
       </dependency>
 
       <dependency>

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ConnectMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ConnectMojo.java
@@ -45,6 +45,7 @@ public class ConnectMojo extends AbstractAndroidMojo
                 {
                     executor.setCaptureStdOut( true );
                     executor.executeCommand( command, parameters );
+                    parameters.clear();
                     // ... now put in wireless mode ...
                     String hostport[] = ip.split( ":" );
                     parameters.add( "tcpip" );

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ConnectMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/ConnectMojo.java
@@ -27,21 +27,34 @@ public class ConnectMojo extends AbstractAndroidMojo
         if ( ips.length > 0 )
         {
             CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
+            executor.setLogger( this.getLog() );
 
             for ( String ip : ips )
             {
                 getLog().debug( "Connecting " + ip );
 
-                // It would be better to use the AndroidDebugBridge class 
+                // It would be better to use the AndroidDebugBridge class
                 // rather than calling the command line tool
                 String command = getAndroidSdk().getAdbPath();
+                // We first have to the put the bridge in tcpip mode or else it will fail to connect
+                // First make sure everything is clean ...
                 List<String> parameters = new ArrayList<String>();
-                parameters.add( "connect" );
-                parameters.add( ip );
+                parameters.add( "kill-server" );
 
                 try
                 {
                     executor.setCaptureStdOut( true );
+                    executor.executeCommand( command, parameters );
+                    // ... now put in wireless mode ...
+                    String hostport[] = ip.split( ":" );
+                    parameters.add( "tcpip" );
+                    parameters.add( hostport[1] );
+                    executor.setCaptureStdOut( true );
+                    executor.executeCommand( command, parameters );
+                    // ... and finally connect
+                    parameters.clear();
+                    parameters.add( "connect" );
+                    parameters.add( ip );
                     executor.executeCommand( command, parameters );
                 }
                 catch ( ExecutionException e )

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/DisconnectMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/DisconnectMojo.java
@@ -43,7 +43,7 @@ public class DisconnectMojo extends AbstractAndroidMojo
                 try
                 {
                     executor.setCaptureStdOut( true );
-                    executor.executeCommand( command, parameters );
+                    executor.executeCommand( command, parameters, false );
                 }
                 catch ( ExecutionException e )
                 {

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/DisconnectMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/DisconnectMojo.java
@@ -25,10 +25,12 @@ public class DisconnectMojo extends AbstractAndroidMojo
         if ( ips.length > 0 )
         {
             CommandExecutor executor = CommandExecutor.Factory.createDefaultCommmandExecutor();
+            executor.setLogger( this.getLog() );
 
             for ( String ip : ips )
             {
                 getLog().debug( "Disconnecting " + ip );
+
 
                 // It would be better to use the AndroidDebugBridge class 
                 // rather than calling the command line tool


### PR DESCRIPTION
Connect and disconnect do not work because the logger is null resulting in an NPE.
Furthermore connecting over tcpip needs tcpip enabled.