### PR TITLE
also extract duplicates from output folder

### DIFF
--- a/src/test/java/com/simpligility/maven/plugins/android/phase09package/ExtractDuplicatesIT.java
+++ b/src/test/java/com/simpligility/maven/plugins/android/phase09package/ExtractDuplicatesIT.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2014 simpligility technologies inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.jayway.maven.plugins.android.phase09package;
+package com.simpligility.maven.plugins.android.phase09package;
 
 import io.takari.maven.testing.TestResources;
 import io.takari.maven.testing.executor.MavenExecutionResult;
@@ -58,15 +43,17 @@ public class ExtractDuplicatesIT {
         result.assertErrorFreeLog();
         result.assertLogText( "Duplicate file resourceA" );
         result.assertLogText( "Duplicate file resourceB" );
+        result.assertLogText( "Duplicate file resourceC" );
         File apk = new File(result.getBasedir().getAbsolutePath()+"/duplicates-app/target", "duplicates-app.apk");
         assertNotNull("APK Not Null", apk);
         ZipFile apkFile = new ZipFile(apk);
         assertNotNull(apkFile.getEntry("resourceA"));
         assertNotNull(apkFile.getEntry("resourceB"));
+        assertNotNull(apkFile.getEntry("resourceC"));
 
         //test services
         assertEntryContents(apkFile, "META-INF/services/com.jayway.maven.plugins.android.TestInterface",
-                "ImplementationA\nImplementationB\nImplementationC");
+                "ImplementationA\nImplementationB\nImplementationC\nImplementationApp");
 
         //test xpath xml
         assertEntryContents( apkFile, "META-INF/kmodule.xml", expectedKmodule );

--- a/src/test/projects/duplicates/duplicates-app/src/main/resources/META-INF/services/com.jayway.maven.plugins.android.TestInterface
+++ b/src/test/projects/duplicates/duplicates-app/src/main/resources/META-INF/services/com.jayway.maven.plugins.android.TestInterface
@@ -1,0 +1,1 @@
+ImplementationApp

--- a/src/test/projects/duplicates/duplicates-app/src/main/resources/resourceC
+++ b/src/test/projects/duplicates/duplicates-app/src/main/resources/resourceC
@@ -1,0 +1,1 @@
+test content

--- a/src/test/projects/duplicates/duplicates-lib-b/src/main/resources/resourceC
+++ b/src/test/projects/duplicates/duplicates-lib-b/src/main/resources/resourceC
@@ -1,0 +1,1 @@
+test content


### PR DESCRIPTION
extract duplicates functionality only looked at dependent jars, not the project output folder.