### PR TITLE
#704 Include proguard configuration file of all dependencies

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/phase04processclasses/ProguardMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase04processclasses/ProguardMojo.java
@@ -442,16 +442,13 @@ public class ProguardMojo extends AbstractAndroidMojo
             proguardCommands.add( "@" + proguardFile.getAbsolutePath() );
         }
 
-        for ( Artifact artifact : getDirectDependencyArtifacts() )
+        for ( Artifact artifact : getTransitiveDependencyArtifacts( AAR ) )
         {
-            if ( AAR.equals( artifact.getType() ) )
+            File unpackedLibFolder = getUnpackedLibFolder( artifact );
+            File proguardFile = new File( unpackedLibFolder, "proguard.txt" );
+            if ( proguardFile.exists() )
             {
-                File unpackedLibFolder = getUnpackedLibFolder( artifact );
-                File proguardFile = new File( unpackedLibFolder, "proguard.txt" );
-                if ( proguardFile.exists() )
-                {
-                    proguardCommands.add( "@" + proguardFile.getAbsolutePath() );
-                }
+                proguardCommands.add( "@" + proguardFile.getAbsolutePath() );
             }
         }
 


### PR DESCRIPTION
Fix for https://github.com/simpligility/android-maven-plugin/issues/704. 
Adds to the `proguardCommand` the `proguard.txt` files from all dependencies (direct and transitive) instead of direct dependencies only.