### PR TITLE
Resource overlays

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -867,8 +867,8 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 .disablePngCrunching()
                 .generateRIntoPackage( customPackage )
                 .setPathToAndroidManifest( destinationManifestFile )
-                .addResourceDirectoryIfExists( resourceDirectory )
                 .addResourceDirectoriesIfExists( getResourceOverlayDirectories() )
+                .addResourceDirectoryIfExists( resourceDirectory )
                     // Need to include any AAR or APKLIB dependencies when generating R because if any local
                     // resources directly reference dependent resources then R generation will crash.
                 .addResourceDirectoriesIfExists( getLibraryResourceFolders() )


### PR DESCRIPTION
This PR fixes #417 and #573. Note: A similar fix (in GenerateSourcesMojo.generateRForApkLibDependency()) could possibly solve #345 as well, but I haven't had time to verify that (and therefore I will not include a fix for #345 in this PR). 

I tried to use `resourceOverlayDirectory` but ran into problems .... I have specified the following configuration in my pom:

`<resourceOverlayDirectory>src/env/staging/res</resourceOverlayDirectory>`

Without this fix, the project builds fine but when the app starts it (usually) crashes since the resources ids have become messed up.

The problem is the order in which the resource overlay directory and the normal resource directory (src/main/res) ends up being declared in the aapt package command. I observed that the resource overlay directory is declared _after_ the normal resource directory:

`aapt 'package' '-m' '-J' '.../target/generated-sources/r' '-f' '--no-crunch' '-M' '.../target/AndroidManifest.xml' '-S' '.../src/main/res' '-S' '.../src/env/staging/res' '-S' '.../target/unpacked-libs/cas_support-v4_23.4.0/res' ...`

From the aapt man page, it's fairly obvious that the resource overlay directory must be declared **before** any resource directories containing resources that should be overridden:

```
-S  directory in which to find resources.  Multiple directories will be scanned
       and the first match found (left to right) will take precedence.
```

So ... with this fix, the aapt package command instead becomes:

`aapt 'package' '-m' '-J' '.../target/generated-sources/r' '-f' '--no-crunch' '-M' '.../target/AndroidManifest.xml' '-S' '.../src/env/staging/res' '-S' '.../src/main/res' '-S' '.../target/unpacked-libs/cas_support-v4_23.4.0/res' ...`

(with the resource overlay directory being declared first of all resources directories) and the app starts app without crashing and without resources ids being messed up.