### PR TITLE
Update Default SDK Version to API 23

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
@@ -44,7 +44,7 @@ public class AndroidSdk
      * the default API level for the SDK used as a fall back if none is supplied, 
      * should ideally point to the latest available version
      */
-    private static final String DEFAULT_ANDROID_API_LEVEL = "22";
+    private static final String DEFAULT_ANDROID_API_LEVEL = "23";
     /**
      * property file in each platform folder with details about platform.
      */

--- a/src/site/asciidoc/changelog.adoc
+++ b/src/site/asciidoc/changelog.adoc
@@ -7,7 +7,9 @@
 ** fixes https://github.com/simpligility/android-maven-plugin/issues/731
 ** fixes https://github.com/simpligility/android-maven-plugin/issues/716
 ** contributed by https://github.com/zhenkhokh as well as https://github.com/sprylab
-
+* Update to use API level 23 for default Android SDK value
+** see https://github.com/simpligility/android-maven-plugin/pull/733
+** contributed by Casey Kulm https://github.com/caseykulm
 
 == 4.4.2 - Released 2016-05-28
 


### PR DESCRIPTION
In a while this will be able to be changed to API 24, but for now it could definitely stand to be updated to API 23. I'm also not sure if there is any good place (or if it would be desirable) to log in the build process that the android-maven-plugin has decided to choose a default api level, and maybe a reference to the pom option to configure it.