### PR TITLE
Add support to install jar file in aar artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.simpligility.maven.plugins</groupId>
   <artifactId>android-maven-plugin</artifactId>
-  <version>4.5.1-SNAPSHOT</version>
+  <version>4.5.0-jarfix</version>
   <packaging>maven-plugin</packaging>
 
   <name>Android Maven Plugin - android-maven-plugin</name>

--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/AarMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/AarMojo.java
@@ -156,11 +156,6 @@ public class AarMojo extends AbstractAndroidMojo
             // If there is a classifier specified, attach the artifact using that
             projectHelper.attachArtifact( project, AndroidExtension.AAR, classifier, outputFile );
         }
-        if ( attachJar )
-        {
-            final File jarFile = new File( targetDirectory, finalName + ".jar" );
-            projectHelper.attachArtifact( project, "jar", project.getArtifact().getClassifier(), jarFile );
-        }
     }
 
     /**
@@ -174,6 +169,7 @@ public class AarMojo extends AbstractAndroidMojo
         final File obfuscatedJarFile = new File( obfuscatedJar );
         if ( obfuscatedJarFile.exists() )
         {
+            attachJar( obfuscatedJarFile );
             return obfuscatedJarFile;
         }
 
@@ -186,6 +182,7 @@ public class AarMojo extends AbstractAndroidMojo
                     classesJarIncludes,
                     classesJarExcludes );
             jarArchiver.createArchive();
+            attachJar( classesJar );
             return classesJar;
         }
         catch ( ArchiverException e )
@@ -197,6 +194,14 @@ public class AarMojo extends AbstractAndroidMojo
             throw new MojoExecutionException( "IOException while creating ." + classesJar + " file.", e );
         }
 
+    }
+
+    private void attachJar( File jarFile )
+    {
+        if ( attachJar )
+        {
+            projectHelper.attachArtifact( project, "jar", project.getArtifact().getClassifier(), jarFile );
+        }
     }
 
     /**

--- a/src/main/java/com/simpligility/maven/plugins/android/phase09package/AarMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase09package/AarMojo.java
@@ -156,6 +156,11 @@ public class AarMojo extends AbstractAndroidMojo
             // If there is a classifier specified, attach the artifact using that
             projectHelper.attachArtifact( project, AndroidExtension.AAR, classifier, outputFile );
         }
+        if ( attachJar )
+        {
+            final File jarFile = new File( targetDirectory, finalName + ".jar" );
+            projectHelper.attachArtifact( project, "jar", project.getArtifact().getClassifier(), jarFile );
+        }
     }
 
     /**


### PR DESCRIPTION
The documentation for the aar goal claims to support the attachJar parameter. This patch uses the code from the legacy ApklibMojo to add support for building a jar file.