### PR TITLE
Don't generate existing R

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.simpligility.maven.plugins</groupId>
   <artifactId>android-maven-plugin</artifactId>
-  <version>4.5.0-jarfix</version>
+  <version>4.5.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Android Maven Plugin - android-maven-plugin</name>

--- a/src/conf/maven_checks.xml
+++ b/src/conf/maven_checks.xml
@@ -130,7 +130,9 @@ Android Maven Plugin uses the APL v2 but with copyright mentions -->
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="MethodLength"/>
+        <module name="MethodLength">
+            <property name="countEmpty" value="false"/>
+        </module>
         <module name="ParameterNumber">
             <property name="max" value="10"/>
         </module>

--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
@@ -142,7 +142,7 @@ public class AndroidSdk
         // fallback to searching for platform on standard Android platforms (isPlatform() is true)
         for ( IAndroidTarget t: sdkManager.getAndroidTargetManager( null ).getTargets( null ) )
         {
-            if ( t.isPlatform() && t.getVersionName().equals( apiLevel ) )
+            if ( t.isPlatform() && apiLevel.equals( t.getVersionName() ) )
             {
                 return t;
             }

--- a/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/ClassLoaderFactory.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/ClassLoaderFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2009 Jayway AB
+ * Copyright (C) 2007-2008 JVending Masa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.simpligility.maven.plugins.android.phase01generatesources;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Creates a ClassLoader from a Collection of classpath elements.
+ *
+ * @author William Ferguson - william.ferguson@xandar.com.au
+ */
+final class ClassLoaderFactory
+{
+    private final List<String> classpathElements;
+
+    ClassLoaderFactory( List<String> classpathElements )
+    {
+        this.classpathElements = classpathElements;
+    }
+
+    /**
+     * @return ClassLoader containing the classpaths.
+     */
+    ClassLoader create()
+    {
+        final List<URL> urls = new ArrayList<>();
+        for ( final String element : classpathElements )
+        {
+            try
+            {
+                urls.add( new File( element ).toURI().toURL() );
+            }
+            catch ( MalformedURLException e )
+            {
+                throw new IllegalArgumentException( "Could not resolve dependency : " + element, e );
+            }
+        }
+        return new URLClassLoader(
+                urls.toArray( new URL[urls.size()] ),
+                Thread.currentThread().getContextClassLoader()
+        );
+    }
+}


### PR DESCRIPTION
Don't generate R.java if one has already been generated for that package in the compile classpath.
This stops extra R javas being generated for a test-apk that will mirror those from the target APK.