### PR TITLE
Set `android.test.failsafe` to false by default

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/AbstractInstrumentationMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AbstractInstrumentationMojo.java
@@ -115,7 +115,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractAndroidMojo
      * Enables or disables integration safe failure.
      * If <code>true</code> build will not stop on test failure or error.
      */
-    @Parameter( property = "android.test.failsafe", defaultValue = "true" )
+    @Parameter( property = "android.test.failsafe", defaultValue = "false" )
     private Boolean testFailSafe;
 
     /**


### PR DESCRIPTION
To be consistent with `mavenIgnoreTestFailure` and
`mavenIgnoreTestError` the build should by default fail when tests fail.

Not doing this creates surprising situations. These are never good.