### PR TITLE
Unpack.unpack output directory

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/UnpackMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/UnpackMojo.java
@@ -74,6 +74,9 @@ public class UnpackMojo extends AbstractAndroidMojo
     @ConfigPojo( prefix = "unpack" )
     private Unpack unpack;
 
+    @Parameter( defaultValue = "${project.build.directory}/android-classes", readonly = true )
+    private File unpackOutputDirectory;
+
     public void execute() throws MojoExecutionException, MojoFailureException
     {
 
@@ -89,7 +92,7 @@ public class UnpackMojo extends AbstractAndroidMojo
 
     private File unpackClasses() throws MojoExecutionException
     {
-        File outputDirectory = new File( targetDirectory, "android-classes" );
+        File outputDirectory = unpackOutputDirectory;
         if ( lazyLibraryUnpack && outputDirectory.exists() )
         {
             getLog().info( "skip library unpacking due to lazyLibraryUnpack policy" );
@@ -141,7 +144,10 @@ public class UnpackMojo extends AbstractAndroidMojo
 
         try
         {
-            FileUtils.copyDirectory( projectOutputDirectory, outputDirectory );
+            if ( !projectOutputDirectory.equals( outputDirectory ) )
+            {
+                FileUtils.copyDirectory( projectOutputDirectory, outputDirectory );
+            }
         }
         catch ( IOException e )
         {

--- a/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/UnpackMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/standalonemojos/UnpackMojo.java
@@ -77,6 +77,9 @@ public class UnpackMojo extends AbstractAndroidMojo
     @Parameter( defaultValue = "${project.build.directory}/android-classes", readonly = true )
     private File unpackOutputDirectory;
 
+    @Parameter( defaultValue = "false", readonly = true )
+    private boolean includeNonClassFiles;
+
     public void execute() throws MojoExecutionException, MojoFailureException
     {
 
@@ -162,6 +165,11 @@ public class UnpackMojo extends AbstractAndroidMojo
         String entName = jarEntry.getName();
 
         if ( entName.endsWith( ".class" ) )
+        {
+            return true;
+        }
+
+        if ( includeNonClassFiles && !entName.startsWith( "META-INF/" ) )
         {
             return true;
         }


### PR DESCRIPTION
This PR adds new two configuration options to make the `unpack` goal more precise:

* `unpackOutputDirectory` to change the originally hardcoded `android-classes` directory.
* `includeNonClassFiles`to allow non-`.class` files that are not specified in the manifest.
