### PR TITLE
Added the d8UseRunner option to the plugin configuration to make d8 work since build-tools;29.0.1

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/AndroidSdk.java
@@ -232,6 +232,20 @@ public class AndroidSdk
     }
     
     /**
+     * Get the path for build-tools directory
+     * @return
+     */
+    public String getBuildToolsDirectoryPath()
+    {
+        File buildTools = getBuildToolInfo().getLocation();
+        if ( buildTools.exists() )
+        {
+            return buildTools.getAbsolutePath();
+        }
+        throw new InvalidSdkException( "Cannot find " + buildTools );
+    }
+
+    /**
      * Get the path for build-tools lib directory
      * @return
      */


### PR DESCRIPTION
`build-tools;29.0.1` and later provide the `d8.jar` library without the `Main-Class` entry in its manifest, therefore making the current `D8Mojo.java` unable to work properly. This PR is attempting to fix the behavior.

Items to discuss:

- Changing the behavior:
  - Should 'D8Mojo' provide the flag? (currently suggested implementation)
  - OR should the the plugin resolve the bevavior by assuming the specific build tools versions (e.g., "always lib/d8.jar prior to 29.0.0" and "always d8 in other case")?
  - OR should the plugin peek right into the d8 jar manifest to figure out the preferred behavior?
- I tested the changes only on my Linux Mint machine, and these changes, I believe, cannot work on at least Windows machines (I believe Android SDK for Windows provides d8.bat, "TODO-ed" in the PR). Is there a preferred/cross-platform way of running external scripts in Maven or the plugin?

Please see more at #793.