### PR TITLE
Allowing D8 to be invoked inj build tools 29+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <asm.version>5.0.4</asm.version>
     <!-- Attention - make sure that the tools version is the versions of 
       the transitive dependencies of the builder version -->
-    <android.builder.version>2.3.0</android.builder.version>
-    <android.tools.version>25.3.0</android.tools.version>
+    <android.builder.version>2.3.3</android.builder.version>
+    <android.tools.version>25.3.3</android.tools.version>
   </properties>
 
   <scm>

--- a/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -20,7 +20,6 @@ import com.simpligility.maven.plugins.android.AbstractAndroidMojo;
 import com.simpligility.maven.plugins.android.CommandExecutor;
 import com.simpligility.maven.plugins.android.ExecutionException;
 import com.simpligility.maven.plugins.android.common.AaptCommandBuilder;
-import com.simpligility.maven.plugins.android.common.AaptCommandBuilder.AaptPackageCommandBuilder;
 import com.simpligility.maven.plugins.android.common.DependencyResolver;
 import com.simpligility.maven.plugins.android.common.FileRetriever;
 import com.simpligility.maven.plugins.android.configuration.BuildConfigConstant;
@@ -620,7 +619,12 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
                 {
                     messageBuilder
                             .append( messageBuilder.length() > 0 ? ", " : "    [" )
-                            .append( item.getArtifactId() );
+                            .append( item.getGroupId() )
+                            .append( ":" )
+                            .append( item.getArtifactId() )
+                            .append( ":" )
+                            .append( item.getVersion() )
+                    ;
                 }
                 messageBuilder
                         .append( "] have similar package='" )
@@ -771,7 +775,7 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
 
         genDirectory.mkdirs();
 
-        final AaptPackageCommandBuilder commandBuilder = AaptCommandBuilder
+        final AaptCommandBuilder.AaptPackageCommandBuilder commandBuilder = AaptCommandBuilder
                 .packageResources( getLog() )
                 .makePackageDirectories()
                 .setResourceConstantsFolder( genDirectory )

--- a/src/main/java/com/simpligility/maven/plugins/android/phase08preparepackage/D8Mojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase08preparepackage/D8Mojo.java
@@ -355,20 +355,6 @@ public class D8Mojo extends AbstractAndroidMojo
         }
     }
 
-    private List< String > dexDefaultCommands() throws MojoExecutionException
-    {
-        List< String > commands = jarDefaultCommands();
-        commands.add( getAndroidSdk().getD8JarPath() );
-        return commands;
-    }
-
-    private List<String> jarDefaultCommands()
-    {
-        List< String > commands = javaDefaultCommands();
-        commands.add( "-jar" );
-        return commands;
-    }
-
     private List<String> javaDefaultCommands()
     {
         List< String > commands = new ArrayList< String > ();
@@ -394,7 +380,13 @@ public class D8Mojo extends AbstractAndroidMojo
     private void runD8( CommandExecutor executor )
         throws MojoExecutionException
     {
-        final List< String > commands = dexDefaultCommands();
+        final List< String > commands = javaDefaultCommands();
+
+        // Add d8 class to be invoked (As of Android 30 the D8 class is not included as a main attribute in the Jar).
+        commands.add( "-classpath" );
+        commands.add( getAndroidSdk().getD8JarPath() );
+        commands.add( "com.android.tools.r8.D8" );
+
         final Set< File > inputFiles = getD8InputFiles();
         if ( parsedIntermediate )
         {

--- a/src/test/java/com/simpligility/maven/plugins/android/AndroidSdkTest.java
+++ b/src/test/java/com/simpligility/maven/plugins/android/AndroidSdkTest.java
@@ -85,14 +85,14 @@ public class AndroidSdkTest {
     @Test
     public void validPlatformsAndApiLevels22() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk22 = new AndroidSdk(new File(sdkTestSupport.getEnv_ANDROID_HOME()), "22", null);
+        final AndroidSdk sdk22 = new AndroidSdk(new File(sdkTestSupport.getEnv_ANDROID_HOME()), "22" );
         Assert.assertTrue( sdk22.getAaptPath() != null && !sdk22.getAaptPath().equals( "" ) );
     }
 
     @Test
     public void validPlatformsAndApiLevels25() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk25 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME()), "25", "25.0.3" );
+        final AndroidSdk sdk25 = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME()), "25" );
         Assert.assertTrue( sdk25.getAaptPath() != null && !sdk25.getAaptPath().equals( "" ) );
     }
 
@@ -124,21 +124,21 @@ public class AndroidSdkTest {
     @Test
     public void validPlatformsAndApiLevelsWithDiffBuildTools1() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "25.0.3" );
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "28.0.3" );
         Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
     }
 
     @Test
     public void validPlatformsAndApiLevelsWithDiffBuildTools2() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "24.0.3" );
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "19", "28.0.3" );
         Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
     }
 
     @Test
     public void validPlatformsAndApiLevelsWithDiffBuildTools3() {
         // Remember to add further platforms to .travis.yml if you add more platforms here, otherwise ci build fails
-        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "28", "28.0.3" );
+        final AndroidSdk sdk = new AndroidSdk( new File( sdkTestSupport.getEnv_ANDROID_HOME() ), "28", "30.0.2" );
         Assert.assertTrue( sdk.getAaptPath() != null && !sdk.getAaptPath().equals( "" ) );
     }
 

--- a/src/test/java/com/simpligility/maven/plugins/android/SdkTestSupport.java
+++ b/src/test/java/com/simpligility/maven/plugins/android/SdkTestSupport.java
@@ -32,7 +32,7 @@ public class SdkTestSupport {
     public SdkTestSupport() {
         Assert.assertNotNull("For running the tests, you must have environment variable ANDROID_HOME set to a valid Android SDK 25 directory.", env_ANDROID_HOME);
 
-        sdk_with_platform_default = new AndroidSdk(new File(env_ANDROID_HOME), "25", "25.0.3");
+        sdk_with_platform_default = new AndroidSdk(new File(env_ANDROID_HOME), "25", "30.0.2" );
     }
 
     public String getEnv_ANDROID_HOME() {


### PR DESCRIPTION
Also updated build tools versions in tests to 30.0.2 (which is latest as of 15-NOV-2020)