### PR TITLE
Fix mainDexList so that the filename is separated from the command

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/android/phase08preparepackage/D8Mojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/android/phase08preparepackage/D8Mojo.java
@@ -394,7 +394,8 @@ public class D8Mojo extends AbstractAndroidMojo
         }
         if ( parsedMainDexList != null )
         {
-            commands.add( "--main-dex-list" + parsedMainDexList );
+            commands.add( "--main-dex-list" );
+            commands.add( parsedMainDexList );
         }
         if ( parsedArguments != null )
         {


### PR DESCRIPTION
The mainDexList option was not working - no space between the command and the filename